### PR TITLE
feat: Classic arcade-style name entry for high scores

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -87,15 +87,30 @@ export const GameState = {
   PAUSED: 'paused',
   GAME_OVER: 'gameover',
   LEVEL_COMPLETE: 'levelcomplete',
+  NAME_ENTRY: 'nameentry',
+};
+
+/**
+ * Name entry configuration for high score
+ */
+export const NAME_ENTRY = {
+  MAX_INITIALS: 3,               // Classic arcade: 3 characters
+  ALLOWED_CHARS: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ',
+  DEFAULT_CHAR: 'A',
+  BLINK_RATE: 300,               // Cursor blink rate in ms
+  CONFIRM_DELAY: 500,            // Delay after confirming name
 };
 
 export const Keys = {
   LEFT: ['ArrowLeft', 'KeyA'],
   RIGHT: ['ArrowRight', 'KeyD'],
+  UP: ['ArrowUp', 'KeyW'],
+  DOWN: ['ArrowDown', 'KeyS'],
   FIRE: ['Space'],
   PAUSE: ['KeyP'],
   RESTART: ['KeyR'],
   MUTE: ['KeyM'],
+  CONFIRM: ['Enter'],
 };
 
 /**

--- a/src/game.js
+++ b/src/game.js
@@ -5,6 +5,7 @@ import { EnemyManager } from './managers/enemy-manager.js';
 import { ProjectileManager } from './managers/projectile-manager.js';
 import { CollisionDetector } from './managers/collision-detector.js';
 import { ScoreManager } from './managers/score-manager.js';
+import { NameEntryManager } from './managers/name-entry-manager.js';
 import { SoundManager } from './audio/sound-manager.js';
 import { Player } from './entities/player.js';
 import { Bunker } from './entities/bunker.js';
@@ -22,6 +23,7 @@ export class Game {
     this.enemyManager = new EnemyManager();
     this.projectileManager = new ProjectileManager();
     this.scoreManager = new ScoreManager();
+    this.nameEntryManager = new NameEntryManager();
     this.soundManager = new SoundManager();
 
     // Game state
@@ -42,6 +44,9 @@ export class Game {
     // Level transition
     this.levelTransitionTimer = 0;
     this.levelTransitionDuration = 2000;
+
+    // Name entry tracking
+    this.newHighScoreRank = 0;
 
     // Bind methods
     this.gameLoop = this.gameLoop.bind(this);
@@ -114,6 +119,9 @@ export class Game {
         break;
       case GameState.LEVEL_COMPLETE:
         this.updateLevelComplete(deltaTime);
+        break;
+      case GameState.NAME_ENTRY:
+        this.updateNameEntry(deltaTime);
         break;
     }
 
@@ -213,6 +221,68 @@ export class Game {
     if (this.levelTransitionTimer >= this.levelTransitionDuration) {
       this.startNextLevel();
     }
+  }
+
+  /**
+   * Update name entry state
+   * @param {number} deltaTime
+   */
+  updateNameEntry(deltaTime) {
+    // Check if delay after confirmation is complete
+    if (this.nameEntryManager.isConfirmed()) {
+      if (this.nameEntryManager.update(deltaTime)) {
+        // Transition to game over screen (now showing high scores)
+        this.state = GameState.GAME_OVER;
+      }
+      return;
+    }
+
+    // Handle direct character input (typing letters)
+    const typedChar = this.input.getTypedChar();
+    if (typedChar) {
+      const isComplete = this.nameEntryManager.inputChar(typedChar);
+      this.soundManager.playShoot(); // Use shoot sound for feedback
+      if (isComplete) {
+        this.saveHighScore();
+      }
+      return;
+    }
+
+    // Handle up/down for character selection
+    if (this.input.isUpJustPressed()) {
+      this.nameEntryManager.nextChar();
+      this.soundManager.playShoot();
+    }
+    if (this.input.isDownJustPressed()) {
+      this.nameEntryManager.prevChar();
+      this.soundManager.playShoot();
+    }
+
+    // Handle left/right for cursor movement
+    if (this.input.isLeftJustPressed()) {
+      this.nameEntryManager.prevPosition();
+    }
+    if (this.input.isRightJustPressed()) {
+      this.nameEntryManager.nextPosition();
+    }
+
+    // Handle confirm (advance or submit)
+    if (this.input.isConfirmJustPressed()) {
+      const isComplete = this.nameEntryManager.confirm();
+      this.soundManager.playShoot();
+      if (isComplete) {
+        this.saveHighScore();
+      }
+    }
+  }
+
+  /**
+   * Save high score after name entry
+   */
+  saveHighScore() {
+    const initials = this.nameEntryManager.getInitials();
+    this.newHighScoreRank = this.scoreManager.addHighScore(initials);
+    this.soundManager.playLevelComplete();
   }
 
   /**
@@ -375,6 +445,7 @@ export class Game {
     this.explosions = [];
     this.mysteryShip = null;
     this.mysteryShipTimer = 0;
+    this.newHighScoreRank = 0;
 
     this.player = new Player();
     this.createBunkers();
@@ -417,8 +488,21 @@ export class Game {
    * Handle game over
    */
   gameOver() {
-    this.state = GameState.GAME_OVER;
-    this.soundManager.playGameOver();
+    // Update level in score manager for high score tracking
+    this.scoreManager.setLevel(this.level);
+
+    // Check if player achieved a high score
+    if (this.scoreManager.isHighScore()) {
+      // Show name entry screen
+      this.nameEntryManager.reset();
+      this.newHighScoreRank = this.scoreManager.getScoreRank();
+      this.state = GameState.NAME_ENTRY;
+      this.soundManager.playPowerUp(); // Play celebratory sound
+    } else {
+      // Regular game over
+      this.state = GameState.GAME_OVER;
+      this.soundManager.playGameOver();
+    }
   }
 
   /**
@@ -469,10 +553,12 @@ export class Game {
     const ctx = this.renderer.getContext();
     const controllerStatus = this.input.getControllerStatus();
     const hasController = controllerStatus.connected;
+    const highScores = this.scoreManager.getTopHighScores(5);
 
     switch (this.state) {
       case GameState.MENU:
-        this.renderer.drawStartScreen(controllerStatus);
+        // Use the enhanced start screen with high scores
+        this.renderer.drawStartScreenWithScores(controllerStatus, highScores);
         break;
 
       case GameState.PLAYING:
@@ -485,6 +571,18 @@ export class Game {
         } else if (this.state === GameState.LEVEL_COMPLETE) {
           this.renderer.drawLevelComplete(this.level);
         }
+        break;
+
+      case GameState.NAME_ENTRY:
+        this.renderGame();
+        this.renderer.drawNameEntry(
+          this.scoreManager.getScore(),
+          this.newHighScoreRank,
+          this.nameEntryManager.initials,
+          this.nameEntryManager.getCurrentPosition(),
+          this.nameEntryManager.isConfirmed(),
+          hasController
+        );
         break;
 
       case GameState.GAME_OVER:

--- a/src/managers/input-handler.js
+++ b/src/managers/input-handler.js
@@ -121,8 +121,11 @@ export class InputHandler {
     return (
       Keys.LEFT.includes(code) ||
       Keys.RIGHT.includes(code) ||
+      Keys.UP.includes(code) ||
+      Keys.DOWN.includes(code) ||
       Keys.FIRE.includes(code) ||
-      Keys.PAUSE.includes(code)
+      Keys.PAUSE.includes(code) ||
+      Keys.CONFIRM.includes(code)
     );
   }
 
@@ -467,6 +470,99 @@ export class InputHandler {
     if (this.isGamepadButtonJustPressed(GamepadButtons.Y)) return true;
 
     return false;
+  }
+
+  // ======================
+  // NAME ENTRY INPUT
+  // ======================
+
+  /**
+   * Check if up was just pressed (keyboard or gamepad)
+   * @returns {boolean}
+   */
+  isUpJustPressed() {
+    // Keyboard
+    if (this.isKeyJustPressed(Keys.UP)) return true;
+
+    // Gamepad D-Pad
+    if (this.isGamepadButtonJustPressed(GamepadButtons.DPAD_UP)) return true;
+
+    return false;
+  }
+
+  /**
+   * Check if down was just pressed (keyboard or gamepad)
+   * @returns {boolean}
+   */
+  isDownJustPressed() {
+    // Keyboard
+    if (this.isKeyJustPressed(Keys.DOWN)) return true;
+
+    // Gamepad D-Pad
+    if (this.isGamepadButtonJustPressed(GamepadButtons.DPAD_DOWN)) return true;
+
+    return false;
+  }
+
+  /**
+   * Check if left was just pressed (keyboard or gamepad)
+   * @returns {boolean}
+   */
+  isLeftJustPressed() {
+    // Keyboard
+    if (this.isKeyJustPressed(Keys.LEFT)) return true;
+
+    // Gamepad D-Pad
+    if (this.isGamepadButtonJustPressed(GamepadButtons.DPAD_LEFT)) return true;
+
+    return false;
+  }
+
+  /**
+   * Check if right was just pressed (keyboard or gamepad)
+   * @returns {boolean}
+   */
+  isRightJustPressed() {
+    // Keyboard
+    if (this.isKeyJustPressed(Keys.RIGHT)) return true;
+
+    // Gamepad D-Pad
+    if (this.isGamepadButtonJustPressed(GamepadButtons.DPAD_RIGHT)) return true;
+
+    return false;
+  }
+
+  /**
+   * Check if confirm/enter was just pressed (keyboard or gamepad)
+   * @returns {boolean}
+   */
+  isConfirmJustPressed() {
+    // Keyboard - Enter or Space
+    if (this.isKeyJustPressed(Keys.CONFIRM)) return true;
+    if (this.isKeyJustPressed(Keys.FIRE)) return true;
+
+    // Gamepad - A button
+    if (this.isGamepadButtonJustPressed(GamepadButtons.A)) return true;
+
+    return false;
+  }
+
+  /**
+   * Get the last typed character (for direct keyboard input)
+   * Returns the most recent alphanumeric key pressed
+   * @returns {string|null}
+   */
+  getTypedChar() {
+    // Check for letter keys (A-Z)
+    for (const code of this.justPressed) {
+      if (code.startsWith('Key')) {
+        return code.slice(3); // 'KeyA' -> 'A'
+      }
+      if (code.startsWith('Digit')) {
+        return code.slice(5); // 'Digit1' -> '1'
+      }
+    }
+    return null;
   }
 
   // Legacy support - keep isHeld working for keyboard

--- a/src/managers/name-entry-manager.js
+++ b/src/managers/name-entry-manager.js
@@ -1,0 +1,193 @@
+import { NAME_ENTRY } from '../constants.js';
+
+/**
+ * Manages classic arcade-style name entry for high scores
+ * Supports 3-character initials with up/down character selection
+ */
+export class NameEntryManager {
+  constructor() {
+    this.initials = [
+      NAME_ENTRY.DEFAULT_CHAR,
+      NAME_ENTRY.DEFAULT_CHAR,
+      NAME_ENTRY.DEFAULT_CHAR,
+    ];
+    this.currentPosition = 0;
+    this.confirmed = false;
+    this.confirmTimer = 0;
+
+    // Character selection
+    this.allowedChars = NAME_ENTRY.ALLOWED_CHARS;
+  }
+
+  /**
+   * Reset for new name entry session
+   */
+  reset() {
+    this.initials = [
+      NAME_ENTRY.DEFAULT_CHAR,
+      NAME_ENTRY.DEFAULT_CHAR,
+      NAME_ENTRY.DEFAULT_CHAR,
+    ];
+    this.currentPosition = 0;
+    this.confirmed = false;
+    this.confirmTimer = 0;
+  }
+
+  /**
+   * Get the current character index in the allowed characters string
+   * @param {number} position - Position in initials array
+   * @returns {number} Index in allowedChars
+   */
+  getCharIndex(position) {
+    return this.allowedChars.indexOf(this.initials[position]);
+  }
+
+  /**
+   * Move to the next character (up)
+   */
+  nextChar() {
+    if (this.confirmed) return;
+
+    const currentIndex = this.getCharIndex(this.currentPosition);
+    const nextIndex = (currentIndex + 1) % this.allowedChars.length;
+    this.initials[this.currentPosition] = this.allowedChars[nextIndex];
+  }
+
+  /**
+   * Move to the previous character (down)
+   */
+  prevChar() {
+    if (this.confirmed) return;
+
+    const currentIndex = this.getCharIndex(this.currentPosition);
+    const prevIndex =
+      (currentIndex - 1 + this.allowedChars.length) % this.allowedChars.length;
+    this.initials[this.currentPosition] = this.allowedChars[prevIndex];
+  }
+
+  /**
+   * Move cursor to the next position (right)
+   * @returns {boolean} True if moved, false if at end
+   */
+  nextPosition() {
+    if (this.confirmed) return false;
+
+    if (this.currentPosition < NAME_ENTRY.MAX_INITIALS - 1) {
+      this.currentPosition++;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Move cursor to the previous position (left)
+   * @returns {boolean} True if moved, false if at start
+   */
+  prevPosition() {
+    if (this.confirmed) return false;
+
+    if (this.currentPosition > 0) {
+      this.currentPosition--;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Confirm current position and move to next, or finish if at end
+   * @returns {boolean} True if name entry is complete
+   */
+  confirm() {
+    if (this.confirmed) return true;
+
+    if (this.currentPosition < NAME_ENTRY.MAX_INITIALS - 1) {
+      this.currentPosition++;
+      return false;
+    } else {
+      this.confirmed = true;
+      return true;
+    }
+  }
+
+  /**
+   * Update timer for confirmation delay
+   * @param {number} deltaTime
+   * @returns {boolean} True if confirmation delay is complete
+   */
+  update(deltaTime) {
+    if (this.confirmed) {
+      this.confirmTimer += deltaTime;
+      return this.confirmTimer >= NAME_ENTRY.CONFIRM_DELAY;
+    }
+    return false;
+  }
+
+  /**
+   * Check if name entry is fully confirmed
+   * @returns {boolean}
+   */
+  isConfirmed() {
+    return this.confirmed;
+  }
+
+  /**
+   * Check if confirmation delay is complete
+   * @returns {boolean}
+   */
+  isDelayComplete() {
+    return this.confirmed && this.confirmTimer >= NAME_ENTRY.CONFIRM_DELAY;
+  }
+
+  /**
+   * Get the entered initials as a string
+   * @returns {string} 3-character initials
+   */
+  getInitials() {
+    return this.initials.join('');
+  }
+
+  /**
+   * Get current cursor position
+   * @returns {number}
+   */
+  getCurrentPosition() {
+    return this.currentPosition;
+  }
+
+  /**
+   * Get individual character at position
+   * @param {number} position
+   * @returns {string}
+   */
+  getCharAt(position) {
+    return this.initials[position];
+  }
+
+  /**
+   * Set character directly (for keyboard input)
+   * @param {string} char - Single character
+   * @returns {boolean} True if character was valid and set
+   */
+  setChar(char) {
+    if (this.confirmed) return false;
+
+    const upperChar = char.toUpperCase();
+    if (this.allowedChars.includes(upperChar)) {
+      this.initials[this.currentPosition] = upperChar;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Handle direct character input and auto-advance
+   * @param {string} char - Single character
+   * @returns {boolean} True if name entry is complete
+   */
+  inputChar(char) {
+    if (this.setChar(char)) {
+      return this.confirm();
+    }
+    return false;
+  }
+}

--- a/src/managers/score-manager.js
+++ b/src/managers/score-manager.js
@@ -1,37 +1,103 @@
 import { SCORE } from '../constants.js';
 
 /**
- * Manages score and high score
+ * High score entry structure
+ * @typedef {Object} HighScoreEntry
+ * @property {string} initials - 3-character player initials
+ * @property {number} score - Player's score
+ * @property {number} level - Level reached
+ * @property {number} timestamp - Date recorded (ms since epoch)
+ */
+
+/**
+ * Manages score, high scores with initials, and leaderboard
  */
 export class ScoreManager {
+  /**
+   * Maximum number of high scores to keep
+   */
+  static MAX_HIGH_SCORES = 10;
+
   constructor() {
     this.score = 0;
-    this.highScore = this.loadHighScore();
+    this.level = 1;
     this.extraLivesAwarded = 0;
+
+    // Load high scores (array of entries) and legacy high score
+    this.highScores = this.loadHighScores();
+    this.highScore = this.getTopScore();
   }
 
   /**
-   * Load high score from localStorage
-   * @returns {number}
+   * Load high scores from localStorage
+   * @returns {HighScoreEntry[]}
    */
-  loadHighScore() {
+  loadHighScores() {
     try {
-      const saved = localStorage.getItem('retroArcadeHighScore');
-      return saved ? parseInt(saved, 10) : 0;
+      const saved = localStorage.getItem('retroArcadeHighScores');
+      if (saved) {
+        const scores = JSON.parse(saved);
+        if (Array.isArray(scores)) {
+          return scores;
+        }
+      }
+
+      // Check for legacy single high score and migrate
+      const legacyScore = localStorage.getItem('retroArcadeHighScore');
+      if (legacyScore) {
+        const score = parseInt(legacyScore, 10);
+        if (score > 0) {
+          return [{
+            initials: '???',
+            score,
+            level: 1,
+            timestamp: Date.now(),
+          }];
+        }
+      }
+
+      return [];
     } catch (e) {
-      return 0;
+      return [];
     }
   }
 
   /**
-   * Save high score to localStorage
+   * Save high scores to localStorage
    */
-  saveHighScore() {
+  saveHighScores() {
     try {
-      localStorage.setItem('retroArcadeHighScore', this.highScore.toString());
+      localStorage.setItem('retroArcadeHighScores', JSON.stringify(this.highScores));
+      // Also save legacy format for backwards compatibility
+      if (this.highScores.length > 0) {
+        localStorage.setItem('retroArcadeHighScore', this.highScores[0].score.toString());
+      }
     } catch (e) {
       // localStorage not available
     }
+  }
+
+  /**
+   * Get the top score value
+   * @returns {number}
+   */
+  getTopScore() {
+    return this.highScores.length > 0 ? this.highScores[0].score : 0;
+  }
+
+  /**
+   * Load high score from localStorage (legacy support)
+   * @returns {number}
+   */
+  loadHighScore() {
+    return this.getTopScore();
+  }
+
+  /**
+   * Save high score to localStorage (legacy support)
+   */
+  saveHighScore() {
+    this.saveHighScores();
   }
 
   /**
@@ -42,10 +108,9 @@ export class ScoreManager {
   addPoints(points) {
     this.score += points;
 
-    // Check for new high score
+    // Update high score display (but don't save until name entered)
     if (this.score > this.highScore) {
       this.highScore = this.score;
-      this.saveHighScore();
     }
 
     // Check for extra life
@@ -75,10 +140,112 @@ export class ScoreManager {
   }
 
   /**
+   * Set current level (for tracking in high scores)
+   * @param {number} level
+   */
+  setLevel(level) {
+    this.level = level;
+  }
+
+  /**
+   * Get current level
+   * @returns {number}
+   */
+  getLevel() {
+    return this.level;
+  }
+
+  /**
+   * Check if current score qualifies for high score board
+   * @returns {boolean}
+   */
+  isHighScore() {
+    if (this.score === 0) return false;
+
+    // If we have less than MAX scores, any score qualifies
+    if (this.highScores.length < ScoreManager.MAX_HIGH_SCORES) {
+      return true;
+    }
+
+    // Otherwise, must beat the lowest score
+    const lowestScore = this.highScores[this.highScores.length - 1].score;
+    return this.score > lowestScore;
+  }
+
+  /**
+   * Get the rank this score would be (1-based)
+   * @returns {number} Rank (1 = top score), or 0 if not on board
+   */
+  getScoreRank() {
+    if (!this.isHighScore()) return 0;
+
+    for (let i = 0; i < this.highScores.length; i++) {
+      if (this.score > this.highScores[i].score) {
+        return i + 1;
+      }
+    }
+    return this.highScores.length + 1;
+  }
+
+  /**
+   * Add a high score entry with initials
+   * @param {string} initials - 3-character player initials
+   * @returns {number} The rank achieved (1-based), or 0 if not added
+   */
+  addHighScore(initials) {
+    if (!this.isHighScore()) return 0;
+
+    const entry = {
+      initials: initials.toUpperCase().substring(0, 3),
+      score: this.score,
+      level: this.level,
+      timestamp: Date.now(),
+    };
+
+    // Find insertion point
+    let insertIndex = this.highScores.length;
+    for (let i = 0; i < this.highScores.length; i++) {
+      if (this.score > this.highScores[i].score) {
+        insertIndex = i;
+        break;
+      }
+    }
+
+    // Insert and trim to max
+    this.highScores.splice(insertIndex, 0, entry);
+    if (this.highScores.length > ScoreManager.MAX_HIGH_SCORES) {
+      this.highScores.pop();
+    }
+
+    // Save to localStorage
+    this.saveHighScores();
+
+    return insertIndex + 1;
+  }
+
+  /**
+   * Get all high scores
+   * @returns {HighScoreEntry[]}
+   */
+  getHighScores() {
+    return [...this.highScores];
+  }
+
+  /**
+   * Get high scores for display (top N)
+   * @param {number} count - Number of scores to return
+   * @returns {HighScoreEntry[]}
+   */
+  getTopHighScores(count = 5) {
+    return this.highScores.slice(0, count);
+  }
+
+  /**
    * Reset score for new game
    */
   reset() {
     this.score = 0;
+    this.level = 1;
     this.extraLivesAwarded = 0;
   }
 
@@ -90,5 +257,19 @@ export class ScoreManager {
    */
   formatScore(num, digits = 6) {
     return String(num).padStart(digits, '0');
+  }
+
+  /**
+   * Clear all high scores (for testing/reset)
+   */
+  clearHighScores() {
+    this.highScores = [];
+    this.highScore = 0;
+    try {
+      localStorage.removeItem('retroArcadeHighScores');
+      localStorage.removeItem('retroArcadeHighScore');
+    } catch (e) {
+      // localStorage not available
+    }
   }
 }

--- a/src/renderer/canvas-renderer.js
+++ b/src/renderer/canvas-renderer.js
@@ -1,4 +1,4 @@
-import { GAME, UI } from '../constants.js';
+import { GAME, UI, NAME_ENTRY } from '../constants.js';
 import { padNumber } from '../utils/helpers.js';
 
 /**
@@ -318,6 +318,332 @@ export class CanvasRenderer {
       const size = Math.max(2, 6 - frame);
       this.ctx.fillRect(px - size / 2, py - size / 2, size, size);
     }
+  }
+
+  /**
+   * Draw name entry screen (classic arcade style)
+   * @param {number} score - Final score achieved
+   * @param {number} rank - Rank on leaderboard (1-based)
+   * @param {string[]} initials - Current initials array (3 chars)
+   * @param {number} cursorPos - Current cursor position (0-2)
+   * @param {boolean} confirmed - Whether entry is confirmed
+   * @param {boolean} [hasController=false] - Whether controller is connected
+   */
+  drawNameEntry(score, rank, initials, cursorPos, confirmed, hasController = false) {
+    // Semi-transparent overlay
+    this.ctx.fillStyle = 'rgba(0, 0, 0, 0.85)';
+    this.ctx.fillRect(0, 0, GAME.WIDTH, GAME.HEIGHT);
+
+    this.ctx.textAlign = 'center';
+
+    // "NEW HIGH SCORE" header
+    this.ctx.fillStyle = '#FFD700';
+    this.ctx.font = `32px ${UI.FONT_FAMILY}`;
+    this.ctx.fillText('NEW HIGH SCORE!', GAME.WIDTH / 2, 100);
+
+    // Rank display
+    this.ctx.fillStyle = '#00FF00';
+    this.ctx.font = `20px ${UI.FONT_FAMILY}`;
+    this.ctx.fillText(`RANK #${rank}`, GAME.WIDTH / 2, 150);
+
+    // Score display
+    this.ctx.fillStyle = UI.TEXT_COLOR;
+    this.ctx.font = `28px ${UI.FONT_FAMILY}`;
+    this.ctx.fillText(`${padNumber(score, 6)}`, GAME.WIDTH / 2, 200);
+
+    // "ENTER YOUR INITIALS" instruction
+    this.ctx.fillStyle = '#AAAAAA';
+    this.ctx.font = `16px ${UI.FONT_FAMILY}`;
+    this.ctx.fillText('ENTER YOUR INITIALS', GAME.WIDTH / 2, 270);
+
+    // Draw the 3-character entry boxes
+    const boxWidth = 60;
+    const boxHeight = 70;
+    const boxSpacing = 20;
+    const totalWidth = boxWidth * 3 + boxSpacing * 2;
+    const startX = (GAME.WIDTH - totalWidth) / 2;
+    const boxY = 300;
+
+    for (let i = 0; i < 3; i++) {
+      const x = startX + i * (boxWidth + boxSpacing);
+
+      // Box background
+      this.ctx.fillStyle = '#111111';
+      this.ctx.fillRect(x, boxY, boxWidth, boxHeight);
+
+      // Box border
+      const isCurrentPos = i === cursorPos && !confirmed;
+      this.ctx.strokeStyle = isCurrentPos ? '#FFD700' : '#444444';
+      this.ctx.lineWidth = isCurrentPos ? 3 : 2;
+      this.ctx.strokeRect(x, boxY, boxWidth, boxHeight);
+
+      // Character
+      this.ctx.fillStyle = confirmed ? '#00FF00' : (isCurrentPos ? '#FFFFFF' : '#888888');
+      this.ctx.font = `36px ${UI.FONT_FAMILY}`;
+      this.ctx.fillText(initials[i], x + boxWidth / 2, boxY + 50);
+
+      // Blinking cursor under current position
+      if (isCurrentPos && !confirmed) {
+        const blink = Math.floor(Date.now() / NAME_ENTRY.BLINK_RATE) % 2 === 0;
+        if (blink) {
+          this.ctx.fillStyle = '#FFD700';
+          this.ctx.fillRect(x + 10, boxY + boxHeight - 8, boxWidth - 20, 4);
+        }
+      }
+    }
+
+    // Up/Down arrows for current position
+    if (!confirmed) {
+      const currentX = startX + cursorPos * (boxWidth + boxSpacing) + boxWidth / 2;
+
+      // Up arrow
+      this.ctx.fillStyle = '#FFD700';
+      this.drawArrow(currentX, boxY - 15, 'up');
+
+      // Down arrow
+      this.drawArrow(currentX, boxY + boxHeight + 15, 'down');
+    }
+
+    // Instructions
+    this.ctx.fillStyle = '#888888';
+    this.ctx.font = `12px ${UI.FONT_FAMILY}`;
+
+    if (confirmed) {
+      this.ctx.fillStyle = '#00FF00';
+      this.ctx.font = `16px ${UI.FONT_FAMILY}`;
+      this.ctx.fillText('SAVED!', GAME.WIDTH / 2, 450);
+    } else {
+      if (hasController) {
+        this.ctx.fillText('D-PAD UP/DOWN: CHANGE LETTER', GAME.WIDTH / 2, 430);
+        this.ctx.fillText('D-PAD LEFT/RIGHT: MOVE  |  A: CONFIRM', GAME.WIDTH / 2, 455);
+      } else {
+        this.ctx.fillText('UP/DOWN OR W/S: CHANGE LETTER', GAME.WIDTH / 2, 430);
+        this.ctx.fillText('LEFT/RIGHT: MOVE  |  ENTER OR SPACE: CONFIRM', GAME.WIDTH / 2, 455);
+      }
+
+      // Tip for direct keyboard input
+      this.ctx.fillStyle = '#555555';
+      this.ctx.fillText('(OR TYPE LETTERS DIRECTLY)', GAME.WIDTH / 2, 480);
+    }
+
+    this.ctx.textAlign = 'left';
+  }
+
+  /**
+   * Draw an arrow (up or down)
+   * @param {number} x - Center X
+   * @param {number} y - Center Y
+   * @param {'up'|'down'} direction
+   */
+  drawArrow(x, y, direction) {
+    this.ctx.beginPath();
+    if (direction === 'up') {
+      this.ctx.moveTo(x, y - 8);
+      this.ctx.lineTo(x - 10, y + 5);
+      this.ctx.lineTo(x + 10, y + 5);
+    } else {
+      this.ctx.moveTo(x, y + 8);
+      this.ctx.lineTo(x - 10, y - 5);
+      this.ctx.lineTo(x + 10, y - 5);
+    }
+    this.ctx.closePath();
+    this.ctx.fill();
+  }
+
+  /**
+   * Draw high score table
+   * @param {Array<{initials: string, score: number, level: number}>} scores
+   * @param {number} [highlightRank=0] - Rank to highlight (1-based), 0 = none
+   */
+  drawHighScoreTable(scores, highlightRank = 0) {
+    this.ctx.textAlign = 'center';
+
+    // Title
+    this.ctx.fillStyle = '#FFD700';
+    this.ctx.font = `24px ${UI.FONT_FAMILY}`;
+    this.ctx.fillText('HIGH SCORES', GAME.WIDTH / 2, 80);
+
+    // Column headers
+    this.ctx.fillStyle = '#888888';
+    this.ctx.font = `14px ${UI.FONT_FAMILY}`;
+    this.ctx.fillText('RANK', 150, 120);
+    this.ctx.fillText('NAME', 300, 120);
+    this.ctx.fillText('SCORE', 480, 120);
+    this.ctx.fillText('LVL', 620, 120);
+
+    // Divider line
+    this.ctx.strokeStyle = '#444444';
+    this.ctx.lineWidth = 1;
+    this.ctx.beginPath();
+    this.ctx.moveTo(100, 135);
+    this.ctx.lineTo(700, 135);
+    this.ctx.stroke();
+
+    // Score entries
+    const startY = 165;
+    const rowHeight = 35;
+
+    for (let i = 0; i < Math.min(scores.length, 10); i++) {
+      const entry = scores[i];
+      const y = startY + i * rowHeight;
+      const rank = i + 1;
+      const isHighlighted = rank === highlightRank;
+
+      // Background highlight for new entry
+      if (isHighlighted) {
+        const blink = Math.floor(Date.now() / 400) % 2 === 0;
+        if (blink) {
+          this.ctx.fillStyle = 'rgba(255, 215, 0, 0.2)';
+          this.ctx.fillRect(100, y - 20, 600, rowHeight);
+        }
+      }
+
+      // Rank
+      this.ctx.fillStyle = isHighlighted ? '#FFD700' : this.getRankColor(rank);
+      this.ctx.font = `16px ${UI.FONT_FAMILY}`;
+      this.ctx.fillText(`${rank}.`, 150, y);
+
+      // Initials
+      this.ctx.fillStyle = isHighlighted ? '#FFD700' : UI.TEXT_COLOR;
+      this.ctx.fillText(entry.initials, 300, y);
+
+      // Score
+      this.ctx.fillText(padNumber(entry.score, 6), 480, y);
+
+      // Level
+      this.ctx.fillStyle = isHighlighted ? '#FFD700' : '#888888';
+      this.ctx.fillText(String(entry.level), 620, y);
+    }
+
+    // Fill empty slots
+    for (let i = scores.length; i < 10; i++) {
+      const y = startY + i * rowHeight;
+      this.ctx.fillStyle = '#444444';
+      this.ctx.font = `16px ${UI.FONT_FAMILY}`;
+      this.ctx.fillText(`${i + 1}.`, 150, y);
+      this.ctx.fillText('---', 300, y);
+      this.ctx.fillText('------', 480, y);
+      this.ctx.fillText('-', 620, y);
+    }
+
+    this.ctx.textAlign = 'left';
+  }
+
+  /**
+   * Get color for rank display
+   * @param {number} rank
+   * @returns {string} Color code
+   */
+  getRankColor(rank) {
+    switch (rank) {
+      case 1: return '#FFD700'; // Gold
+      case 2: return '#C0C0C0'; // Silver
+      case 3: return '#CD7F32'; // Bronze
+      default: return UI.TEXT_COLOR;
+    }
+  }
+
+  /**
+   * Draw start screen with high scores integrated
+   * @param {Object} [controllerStatus] - Controller connection status
+   * @param {Array} [highScores=[]] - High scores to display
+   */
+  drawStartScreenWithScores(controllerStatus = null, highScores = []) {
+    this.ctx.fillStyle = GAME.BACKGROUND_COLOR;
+    this.ctx.fillRect(0, 0, GAME.WIDTH, GAME.HEIGHT);
+
+    // Title
+    this.ctx.fillStyle = '#00FF00';
+    this.ctx.font = `36px ${UI.FONT_FAMILY}`;
+    this.ctx.textAlign = 'center';
+    this.ctx.fillText('RETRO ARCADE', GAME.WIDTH / 2, 80);
+
+    this.ctx.fillStyle = '#FF6600';
+    this.ctx.fillText('SPACE INVADERS', GAME.WIDTH / 2, 120);
+
+    // High scores (compact view)
+    if (highScores.length > 0) {
+      this.ctx.fillStyle = '#FFD700';
+      this.ctx.font = `14px ${UI.FONT_FAMILY}`;
+      this.ctx.fillText('HIGH SCORES', GAME.WIDTH / 2, 165);
+
+      this.ctx.font = `12px ${UI.FONT_FAMILY}`;
+      const displayScores = highScores.slice(0, 5);
+      let y = 190;
+      for (let i = 0; i < displayScores.length; i++) {
+        const entry = displayScores[i];
+        this.ctx.fillStyle = this.getRankColor(i + 1);
+        this.ctx.fillText(
+          `${i + 1}. ${entry.initials}  ${padNumber(entry.score, 6)}`,
+          GAME.WIDTH / 2,
+          y
+        );
+        y += 22;
+      }
+    }
+
+    // Instructions - Keyboard
+    this.ctx.fillStyle = '#AAAAAA';
+    this.ctx.font = `12px ${UI.FONT_FAMILY}`;
+    const instructionY = highScores.length > 0 ? 320 : 200;
+    this.ctx.fillText('KEYBOARD', GAME.WIDTH / 2, instructionY);
+
+    this.ctx.fillStyle = UI.TEXT_COLOR;
+    this.ctx.font = `14px ${UI.FONT_FAMILY}`;
+
+    const keyboardInstructions = [
+      '← →  or  A D  :  MOVE',
+      'SPACE  :  FIRE',
+      'P  :  PAUSE    M  :  MUTE',
+    ];
+
+    let y = instructionY + 25;
+    for (const line of keyboardInstructions) {
+      this.ctx.fillText(line, GAME.WIDTH / 2, y);
+      y += 28;
+    }
+
+    // Instructions - Controller
+    this.ctx.fillStyle = '#AAAAAA';
+    this.ctx.font = `12px ${UI.FONT_FAMILY}`;
+    this.ctx.fillText('CONTROLLER', GAME.WIDTH / 2, y + 10);
+
+    this.ctx.fillStyle = UI.TEXT_COLOR;
+    this.ctx.font = `14px ${UI.FONT_FAMILY}`;
+
+    const controllerInstructions = [
+      'D-PAD / STICK  :  MOVE',
+      'A / RB / RT  :  FIRE',
+      'START  :  PAUSE',
+    ];
+
+    y += 35;
+    for (const line of controllerInstructions) {
+      this.ctx.fillText(line, GAME.WIDTH / 2, y);
+      y += 28;
+    }
+
+    // Controller status indicator
+    if (controllerStatus) {
+      if (controllerStatus.connected) {
+        this.ctx.fillStyle = '#00FF00';
+        this.ctx.font = `12px ${UI.FONT_FAMILY}`;
+        this.ctx.fillText(`🎮 ${controllerStatus.name} CONNECTED`, GAME.WIDTH / 2, y + 15);
+      } else {
+        this.ctx.fillStyle = '#666666';
+        this.ctx.font = `12px ${UI.FONT_FAMILY}`;
+        this.ctx.fillText('🎮 NO CONTROLLER DETECTED', GAME.WIDTH / 2, y + 15);
+      }
+    }
+
+    // Blinking start text
+    if (Math.floor(Date.now() / 500) % 2 === 0) {
+      this.ctx.fillStyle = '#FFFF00';
+      this.ctx.font = `20px ${UI.FONT_FAMILY}`;
+      this.ctx.fillText('PRESS SPACE OR A TO START', GAME.WIDTH / 2, 570);
+    }
+
+    this.ctx.textAlign = 'left';
   }
 
   /**

--- a/tests/managers/name-entry-manager.test.js
+++ b/tests/managers/name-entry-manager.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NameEntryManager } from '../../src/managers/name-entry-manager.js';
+import { NAME_ENTRY } from '../../src/constants.js';
+
+describe('NameEntryManager', () => {
+  let nameEntry;
+
+  beforeEach(() => {
+    nameEntry = new NameEntryManager();
+  });
+
+  describe('initialization', () => {
+    it('should initialize with default characters', () => {
+      expect(nameEntry.getInitials()).toBe('AAA');
+      expect(nameEntry.getCurrentPosition()).toBe(0);
+      expect(nameEntry.isConfirmed()).toBe(false);
+    });
+
+    it('should have correct allowed characters', () => {
+      expect(nameEntry.allowedChars).toBe(NAME_ENTRY.ALLOWED_CHARS);
+      expect(nameEntry.allowedChars).toContain('A');
+      expect(nameEntry.allowedChars).toContain('Z');
+      expect(nameEntry.allowedChars).toContain('0');
+      expect(nameEntry.allowedChars).toContain('9');
+      expect(nameEntry.allowedChars).toContain(' ');
+    });
+  });
+
+  describe('character navigation', () => {
+    it('should cycle to next character with nextChar()', () => {
+      nameEntry.nextChar();
+      expect(nameEntry.getCharAt(0)).toBe('B');
+    });
+
+    it('should cycle to previous character with prevChar()', () => {
+      nameEntry.prevChar();
+      // Should wrap around to end of allowed characters
+      const lastChar = NAME_ENTRY.ALLOWED_CHARS[NAME_ENTRY.ALLOWED_CHARS.length - 1];
+      expect(nameEntry.getCharAt(0)).toBe(lastChar);
+    });
+
+    it('should wrap around at end of character list', () => {
+      // Move to last character
+      const lastIndex = NAME_ENTRY.ALLOWED_CHARS.length - 1;
+      for (let i = 0; i < lastIndex; i++) {
+        nameEntry.nextChar();
+      }
+      const lastChar = NAME_ENTRY.ALLOWED_CHARS[lastIndex];
+      expect(nameEntry.getCharAt(0)).toBe(lastChar);
+
+      // One more should wrap to 'A'
+      nameEntry.nextChar();
+      expect(nameEntry.getCharAt(0)).toBe('A');
+    });
+  });
+
+  describe('cursor position', () => {
+    it('should move cursor to next position', () => {
+      expect(nameEntry.getCurrentPosition()).toBe(0);
+      nameEntry.nextPosition();
+      expect(nameEntry.getCurrentPosition()).toBe(1);
+      nameEntry.nextPosition();
+      expect(nameEntry.getCurrentPosition()).toBe(2);
+    });
+
+    it('should not move past last position', () => {
+      nameEntry.nextPosition();
+      nameEntry.nextPosition();
+      const result = nameEntry.nextPosition();
+      expect(result).toBe(false);
+      expect(nameEntry.getCurrentPosition()).toBe(2);
+    });
+
+    it('should move cursor to previous position', () => {
+      nameEntry.nextPosition();
+      nameEntry.nextPosition();
+      expect(nameEntry.getCurrentPosition()).toBe(2);
+      nameEntry.prevPosition();
+      expect(nameEntry.getCurrentPosition()).toBe(1);
+    });
+
+    it('should not move before first position', () => {
+      const result = nameEntry.prevPosition();
+      expect(result).toBe(false);
+      expect(nameEntry.getCurrentPosition()).toBe(0);
+    });
+  });
+
+  describe('character modification at positions', () => {
+    it('should modify character at current position only', () => {
+      nameEntry.nextChar(); // First position -> B
+      expect(nameEntry.getInitials()).toBe('BAA');
+
+      nameEntry.nextPosition();
+      nameEntry.nextChar(); // Second position -> B
+      expect(nameEntry.getInitials()).toBe('BBA');
+
+      nameEntry.nextPosition();
+      nameEntry.nextChar(); // Third position -> B
+      expect(nameEntry.getInitials()).toBe('BBB');
+    });
+
+    it('should allow setting character directly', () => {
+      expect(nameEntry.setChar('X')).toBe(true);
+      expect(nameEntry.getCharAt(0)).toBe('X');
+    });
+
+    it('should reject invalid characters', () => {
+      expect(nameEntry.setChar('!')).toBe(false);
+      expect(nameEntry.getCharAt(0)).toBe('A');
+    });
+
+    it('should handle lowercase input', () => {
+      expect(nameEntry.setChar('z')).toBe(true);
+      expect(nameEntry.getCharAt(0)).toBe('Z');
+    });
+  });
+
+  describe('confirm behavior', () => {
+    it('should advance position on confirm until end', () => {
+      expect(nameEntry.confirm()).toBe(false);
+      expect(nameEntry.getCurrentPosition()).toBe(1);
+
+      expect(nameEntry.confirm()).toBe(false);
+      expect(nameEntry.getCurrentPosition()).toBe(2);
+
+      expect(nameEntry.confirm()).toBe(true);
+      expect(nameEntry.isConfirmed()).toBe(true);
+    });
+
+    it('should not allow changes after confirmation', () => {
+      nameEntry.confirm();
+      nameEntry.confirm();
+      nameEntry.confirm(); // Now confirmed
+
+      nameEntry.nextChar();
+      expect(nameEntry.getInitials()).toBe('AAA'); // No change
+    });
+
+    it('should not allow cursor movement after confirmation', () => {
+      nameEntry.confirm();
+      nameEntry.confirm();
+      nameEntry.confirm();
+
+      expect(nameEntry.nextPosition()).toBe(false);
+      expect(nameEntry.prevPosition()).toBe(false);
+    });
+  });
+
+  describe('inputChar (direct input with auto-advance)', () => {
+    it('should set character and advance position', () => {
+      expect(nameEntry.inputChar('J')).toBe(false);
+      expect(nameEntry.getCharAt(0)).toBe('J');
+      expect(nameEntry.getCurrentPosition()).toBe(1);
+    });
+
+    it('should complete entry after third character', () => {
+      nameEntry.inputChar('A');
+      nameEntry.inputChar('B');
+      expect(nameEntry.inputChar('C')).toBe(true);
+      expect(nameEntry.getInitials()).toBe('ABC');
+      expect(nameEntry.isConfirmed()).toBe(true);
+    });
+
+    it('should reject invalid characters', () => {
+      expect(nameEntry.inputChar('!')).toBe(false);
+      expect(nameEntry.getCurrentPosition()).toBe(0);
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset to initial state', () => {
+      nameEntry.inputChar('X');
+      nameEntry.inputChar('Y');
+      nameEntry.inputChar('Z');
+      expect(nameEntry.isConfirmed()).toBe(true);
+
+      nameEntry.reset();
+
+      expect(nameEntry.getInitials()).toBe('AAA');
+      expect(nameEntry.getCurrentPosition()).toBe(0);
+      expect(nameEntry.isConfirmed()).toBe(false);
+    });
+  });
+
+  describe('confirmation delay', () => {
+    it('should track confirmation delay timer', () => {
+      nameEntry.confirm();
+      nameEntry.confirm();
+      nameEntry.confirm(); // Confirmed
+
+      expect(nameEntry.isDelayComplete()).toBe(false);
+
+      // Simulate time passing
+      nameEntry.update(NAME_ENTRY.CONFIRM_DELAY - 1);
+      expect(nameEntry.isDelayComplete()).toBe(false);
+
+      nameEntry.update(2);
+      expect(nameEntry.isDelayComplete()).toBe(true);
+    });
+
+    it('should not track delay until confirmed', () => {
+      expect(nameEntry.update(1000)).toBe(false);
+      expect(nameEntry.isDelayComplete()).toBe(false);
+    });
+  });
+});

--- a/tests/managers/score-manager.test.js
+++ b/tests/managers/score-manager.test.js
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ScoreManager } from '../../src/managers/score-manager.js';
+
+describe('ScoreManager', () => {
+  let scoreManager;
+
+  // Mock localStorage
+  const localStorageMock = (() => {
+    let store = {};
+    return {
+      getItem: vi.fn((key) => store[key] || null),
+      setItem: vi.fn((key, value) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        store = {};
+      }),
+    };
+  })();
+
+  beforeEach(() => {
+    // Setup localStorage mock
+    Object.defineProperty(global, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    });
+    localStorageMock.clear();
+    vi.clearAllMocks();
+
+    scoreManager = new ScoreManager();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('basic scoring', () => {
+    it('should start with zero score', () => {
+      expect(scoreManager.getScore()).toBe(0);
+    });
+
+    it('should add points correctly', () => {
+      scoreManager.addPoints(100);
+      expect(scoreManager.getScore()).toBe(100);
+
+      scoreManager.addPoints(50);
+      expect(scoreManager.getScore()).toBe(150);
+    });
+
+    it('should reset score for new game', () => {
+      scoreManager.addPoints(500);
+      scoreManager.setLevel(3);
+      scoreManager.reset();
+
+      expect(scoreManager.getScore()).toBe(0);
+      expect(scoreManager.getLevel()).toBe(1);
+    });
+  });
+
+  describe('level tracking', () => {
+    it('should track level', () => {
+      expect(scoreManager.getLevel()).toBe(1);
+      scoreManager.setLevel(5);
+      expect(scoreManager.getLevel()).toBe(5);
+    });
+  });
+
+  describe('high score detection', () => {
+    it('should detect first score as high score', () => {
+      scoreManager.addPoints(100);
+      expect(scoreManager.isHighScore()).toBe(true);
+    });
+
+    it('should detect zero score as not a high score', () => {
+      expect(scoreManager.isHighScore()).toBe(false);
+    });
+
+    it('should calculate correct rank', () => {
+      scoreManager.addPoints(100);
+      expect(scoreManager.getScoreRank()).toBe(1);
+    });
+
+    it('should calculate rank among existing scores', () => {
+      // Add some scores
+      scoreManager.addPoints(100);
+      scoreManager.addHighScore('AAA');
+      scoreManager.reset();
+
+      scoreManager.addPoints(200);
+      scoreManager.addHighScore('BBB');
+      scoreManager.reset();
+
+      scoreManager.addPoints(150);
+      expect(scoreManager.getScoreRank()).toBe(2); // Between 200 and 100
+    });
+  });
+
+  describe('high score management', () => {
+    it('should add high score entry', () => {
+      scoreManager.addPoints(1000);
+      scoreManager.setLevel(5);
+
+      const rank = scoreManager.addHighScore('ACE');
+      expect(rank).toBe(1);
+
+      const scores = scoreManager.getHighScores();
+      expect(scores.length).toBe(1);
+      expect(scores[0].initials).toBe('ACE');
+      expect(scores[0].score).toBe(1000);
+      expect(scores[0].level).toBe(5);
+    });
+
+    it('should sort high scores correctly', () => {
+      scoreManager.addPoints(100);
+      scoreManager.addHighScore('LOW');
+      scoreManager.reset();
+
+      scoreManager.addPoints(300);
+      scoreManager.addHighScore('HI');
+      scoreManager.reset();
+
+      scoreManager.addPoints(200);
+      scoreManager.addHighScore('MID');
+
+      const scores = scoreManager.getHighScores();
+      expect(scores[0].initials).toBe('HI');
+      expect(scores[1].initials).toBe('MID');
+      expect(scores[2].initials).toBe('LOW');
+    });
+
+    it('should limit high scores to MAX_HIGH_SCORES', () => {
+      for (let i = 0; i < 15; i++) {
+        scoreManager.reset();
+        scoreManager.addPoints((i + 1) * 100);
+        scoreManager.addHighScore(`P${i.toString().padStart(2, '0')}`);
+      }
+
+      const scores = scoreManager.getHighScores();
+      expect(scores.length).toBe(ScoreManager.MAX_HIGH_SCORES);
+      expect(scores[0].score).toBe(1500); // Highest
+      expect(scores[9].score).toBe(600); // 10th highest
+    });
+
+    it('should not add score below lowest when board is full', () => {
+      // Fill up the board with scores 100-1000
+      for (let i = 0; i < 10; i++) {
+        scoreManager.reset();
+        scoreManager.addPoints((i + 1) * 100);
+        scoreManager.addHighScore(`P${i}`);
+      }
+
+      scoreManager.reset();
+      scoreManager.addPoints(50); // Below lowest (100)
+
+      expect(scoreManager.isHighScore()).toBe(false);
+      expect(scoreManager.getScoreRank()).toBe(0);
+      expect(scoreManager.addHighScore('LOW')).toBe(0);
+    });
+
+    it('should get top N high scores', () => {
+      for (let i = 0; i < 8; i++) {
+        scoreManager.reset();
+        scoreManager.addPoints((i + 1) * 100);
+        scoreManager.addHighScore(`P${i}`);
+      }
+
+      const top3 = scoreManager.getTopHighScores(3);
+      expect(top3.length).toBe(3);
+      expect(top3[0].score).toBe(800);
+      expect(top3[2].score).toBe(600);
+    });
+  });
+
+  describe('persistence', () => {
+    it('should save high scores to localStorage', () => {
+      scoreManager.addPoints(500);
+      scoreManager.addHighScore('TST');
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'retroArcadeHighScores',
+        expect.any(String)
+      );
+    });
+
+    it('should load high scores from localStorage', () => {
+      const savedScores = JSON.stringify([
+        { initials: 'AAA', score: 1000, level: 5, timestamp: Date.now() },
+        { initials: 'BBB', score: 500, level: 3, timestamp: Date.now() },
+      ]);
+      localStorageMock.getItem.mockReturnValue(savedScores);
+
+      const newManager = new ScoreManager();
+      const scores = newManager.getHighScores();
+
+      expect(scores.length).toBe(2);
+      expect(scores[0].initials).toBe('AAA');
+    });
+
+    it('should migrate legacy high score format', () => {
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === 'retroArcadeHighScores') return null;
+        if (key === 'retroArcadeHighScore') return '12345';
+        return null;
+      });
+
+      const newManager = new ScoreManager();
+      const scores = newManager.getHighScores();
+
+      expect(scores.length).toBe(1);
+      expect(scores[0].score).toBe(12345);
+      expect(scores[0].initials).toBe('???');
+    });
+
+    it('should clear high scores', () => {
+      scoreManager.addPoints(500);
+      scoreManager.addHighScore('TST');
+
+      scoreManager.clearHighScores();
+
+      expect(scoreManager.getHighScores().length).toBe(0);
+      expect(scoreManager.getHighScore()).toBe(0);
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('retroArcadeHighScores');
+    });
+  });
+
+  describe('formatScore', () => {
+    it('should format score with leading zeros', () => {
+      expect(scoreManager.formatScore(123)).toBe('000123');
+      expect(scoreManager.formatScore(123, 8)).toBe('00000123');
+      expect(scoreManager.formatScore(999999)).toBe('999999');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Issue #1** - Classic arcade-style initial entry system for high scores.

- ✅ 3-character initial entry (A-Z, 0-9) with blinking cursor
- ✅ Two input methods: arrow keys to cycle OR direct keyboard typing
- ✅ Full gamepad/controller support (D-Pad navigation, A button to confirm)
- ✅ High score leaderboard (top 10 entries, persisted in localStorage)
- ✅ Start screen displays top 5 high scores with gold/silver/bronze rank colors
- ✅ Backward compatible with legacy single high score format

## Changes

| File | Changes |
|------|---------|
| `src/managers/name-entry-manager.js` | **New** - Handles 3-char initial input, cursor, character cycling |
| `src/managers/score-manager.js` | Extended with leaderboard (10 entries), initials, level tracking |
| `src/managers/input-handler.js` | Added up/down/confirm detection, typed character support |
| `src/renderer/canvas-renderer.js` | Added name entry screen, high score table rendering |
| `src/game.js` | Integrated NAME_ENTRY state and flow control |
| `src/constants.js` | Added GameState.NAME_ENTRY, NAME_ENTRY config, new keys |

## Test Plan

- [x] All 143 tests pass (`npm run test:run`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing: Complete a game and enter initials
- [ ] Manual testing: Verify high scores persist after refresh
- [ ] Manual testing: Test with gamepad controller

## Screenshots

N/A (run locally with `npm run dev` to test)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)