### PR TITLE
feat: Add parallax scrolling starfield background

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -101,6 +101,19 @@ export const NAME_ENTRY = {
   CONFIRM_DELAY: 500,            // Delay after confirming name
 };
 
+/**
+ * Starfield parallax scrolling configuration
+ * Defines layered star fields for depth effect in background
+ */
+export const STARFIELD = {
+  LAYERS: [
+    { count: 50, size: 1, speed: 0.2, color: '#444444' },  // Far (dim, slow)
+    { count: 40, size: 2, speed: 0.5, color: '#888888' },  // Mid (medium)
+    { count: 30, size: 3, speed: 1.0, color: '#FFFFFF' },  // Near (bright, fast)
+  ],
+  BASE_SPEED: 50, // pixels per second at speed 1.0
+};
+
 export const Keys = {
   LEFT: ['ArrowLeft', 'KeyA'],
   RIGHT: ['ArrowRight', 'KeyD'],

--- a/src/game.js
+++ b/src/game.js
@@ -1,5 +1,6 @@
 import { GAME, GameState, BUNKER, MYSTERY_SHIP } from './constants.js';
 import { CanvasRenderer } from './renderer/canvas-renderer.js';
+import { Starfield } from './renderer/starfield.js';
 import { InputHandler } from './managers/input-handler.js';
 import { EnemyManager } from './managers/enemy-manager.js';
 import { ProjectileManager } from './managers/projectile-manager.js';
@@ -19,6 +20,7 @@ export class Game {
   constructor() {
     // Core systems
     this.renderer = new CanvasRenderer('gameCanvas');
+    this.starfield = new Starfield();
     this.input = new InputHandler();
     this.enemyManager = new EnemyManager();
     this.projectileManager = new ProjectileManager();
@@ -99,6 +101,9 @@ export class Game {
    * @param {number} deltaTime - Time since last frame
    */
   update(deltaTime) {
+    // Always update starfield (renders in all states)
+    this.starfield.update(deltaTime);
+
     // Handle mute toggle in any state
     if (this.input.isMuteJustPressed()) {
       this.soundManager.toggleMute();
@@ -557,7 +562,9 @@ export class Game {
 
     switch (this.state) {
       case GameState.MENU:
-        // Use the enhanced start screen with high scores
+        // Draw starfield background, then start screen with high scores
+        this.renderer.clear();
+        this.starfield.draw(ctx);
         this.renderer.drawStartScreenWithScores(controllerStatus, highScores);
         break;
 
@@ -603,6 +610,9 @@ export class Game {
     const ctx = this.renderer.getContext();
 
     this.renderer.clear();
+
+    // Draw starfield (background - behind all game elements)
+    this.starfield.draw(ctx);
 
     // Draw bunkers
     for (const bunker of this.bunkers) {

--- a/src/renderer/canvas-renderer.js
+++ b/src/renderer/canvas-renderer.js
@@ -219,12 +219,10 @@ export class CanvasRenderer {
 
   /**
    * Draw start screen
+   * Note: Does not clear canvas - starfield is drawn behind in game.js
    * @param {Object} [controllerStatus] - Controller connection status
    */
   drawStartScreen(controllerStatus = null) {
-    this.ctx.fillStyle = GAME.BACKGROUND_COLOR;
-    this.ctx.fillRect(0, 0, GAME.WIDTH, GAME.HEIGHT);
-
     // Title
     this.ctx.fillStyle = '#00FF00';
     this.ctx.font = `36px ${UI.FONT_FAMILY}`;
@@ -549,8 +547,7 @@ export class CanvasRenderer {
    * @param {Array} [highScores=[]] - High scores to display
    */
   drawStartScreenWithScores(controllerStatus = null, highScores = []) {
-    this.ctx.fillStyle = GAME.BACKGROUND_COLOR;
-    this.ctx.fillRect(0, 0, GAME.WIDTH, GAME.HEIGHT);
+    // Note: Canvas clearing and starfield are handled by Game.render()
 
     // Title
     this.ctx.fillStyle = '#00FF00';

--- a/src/renderer/starfield.js
+++ b/src/renderer/starfield.js
@@ -1,0 +1,95 @@
+import { GAME, STARFIELD } from '../constants.js';
+
+/**
+ * Starfield class for parallax scrolling background
+ * Renders 3 layers of stars with different speeds and visual properties
+ * to create a sense of depth and movement
+ */
+export class Starfield {
+  /**
+   * Create a new Starfield
+   * @param {number} [width=GAME.WIDTH] - Canvas width
+   * @param {number} [height=GAME.HEIGHT] - Canvas height
+   */
+  constructor(width = GAME.WIDTH, height = GAME.HEIGHT) {
+    this.width = width;
+    this.height = height;
+    this.baseSpeed = STARFIELD.BASE_SPEED;
+
+    // Layer definitions from constants with star arrays
+    this.layers = STARFIELD.LAYERS.map(layerConfig => ({
+      count: layerConfig.count,
+      size: layerConfig.size,
+      color: layerConfig.color,
+      speed: layerConfig.speed,
+      stars: [],
+    }));
+
+    // Initialize stars for each layer
+    this.initializeStars();
+  }
+
+  /**
+   * Initialize star positions randomly for all layers
+   * Uses count from STARFIELD constants
+   */
+  initializeStars() {
+    for (const layer of this.layers) {
+      for (let i = 0; i < layer.count; i++) {
+        const star = {
+          x: Math.random() * this.width,
+          y: Math.random() * this.height,
+        };
+        layer.stars.push(star);
+      }
+    }
+  }
+
+  /**
+   * Update star positions based on deltaTime
+   * Stars move downward (simulating vertical scrolling) at different speeds
+   * Stars wrap around when they pass the bottom of the screen
+   * @param {number} deltaTime - Time elapsed since last update in milliseconds
+   */
+  update(deltaTime) {
+    // Convert deltaTime from milliseconds to seconds for speed calculation
+    const deltaSeconds = deltaTime / 1000;
+
+    for (const layer of this.layers) {
+      for (const star of layer.stars) {
+        // Move star down based on layer speed and base speed
+        // Speed is in pixels per second (baseSpeed * layer.speed)
+        star.y += layer.speed * this.baseSpeed * deltaSeconds;
+
+        // Wrap around: if star goes past bottom, move it to top
+        if (star.y >= this.height) {
+          star.y = -layer.size;
+          // Randomize x position when wrapping
+          star.x = Math.random() * this.width;
+        }
+      }
+    }
+  }
+
+  /**
+   * Draw all stars to the canvas
+   * @param {CanvasRenderingContext2D} ctx - Canvas 2D context
+   */
+  draw(ctx) {
+    // Draw each layer (far to near for proper depth ordering)
+    for (const layer of this.layers) {
+      ctx.fillStyle = layer.color;
+
+      for (const star of layer.stars) {
+        // Draw each star as a filled rectangle
+        // Using integer coordinates for crisp pixel-perfect appearance
+        ctx.fillRect(
+          Math.round(star.x),
+          Math.round(star.y),
+          layer.size,
+          layer.size
+        );
+      }
+    }
+  }
+}

--- a/tests/renderer/starfield.test.js
+++ b/tests/renderer/starfield.test.js
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Starfield } from '../../src/renderer/starfield.js';
+import { GAME, STARFIELD } from '../../src/constants.js';
+
+describe('Starfield', () => {
+  let starfield;
+  let mockCtx;
+
+  beforeEach(() => {
+    starfield = new Starfield(GAME.WIDTH, GAME.HEIGHT);
+    mockCtx = {
+      fillStyle: '',
+      fillRect: vi.fn(),
+    };
+  });
+
+  describe('initialization', () => {
+    it('should initialize with correct canvas dimensions', () => {
+      expect(starfield.width).toBe(GAME.WIDTH);
+      expect(starfield.height).toBe(GAME.HEIGHT);
+    });
+
+    it('should initialize with correct base speed', () => {
+      expect(starfield.baseSpeed).toBe(STARFIELD.BASE_SPEED);
+    });
+
+    it('should create correct number of layers', () => {
+      expect(starfield.layers.length).toBe(STARFIELD.LAYERS.length);
+      expect(starfield.layers.length).toBe(3);
+    });
+
+    it('should create layers with correct structure', () => {
+      for (const layer of starfield.layers) {
+        expect(layer).toHaveProperty('count');
+        expect(layer).toHaveProperty('size');
+        expect(layer).toHaveProperty('color');
+        expect(layer).toHaveProperty('speed');
+        expect(layer).toHaveProperty('stars');
+      }
+    });
+
+    it('should create correct number of stars per layer', () => {
+      for (let i = 0; i < starfield.layers.length; i++) {
+        expect(starfield.layers[i].stars.length).toBe(STARFIELD.LAYERS[i].count);
+      }
+    });
+
+    it('should match layer properties from constants', () => {
+      for (let i = 0; i < starfield.layers.length; i++) {
+        expect(starfield.layers[i].size).toBe(STARFIELD.LAYERS[i].size);
+        expect(starfield.layers[i].color).toBe(STARFIELD.LAYERS[i].color);
+        expect(starfield.layers[i].speed).toBe(STARFIELD.LAYERS[i].speed);
+        expect(starfield.layers[i].count).toBe(STARFIELD.LAYERS[i].count);
+      }
+    });
+  });
+
+  describe('star positioning', () => {
+    it('should initialize stars with x coordinates within canvas bounds', () => {
+      for (const layer of starfield.layers) {
+        for (const star of layer.stars) {
+          expect(star.x).toBeGreaterThanOrEqual(0);
+          expect(star.x).toBeLessThanOrEqual(GAME.WIDTH);
+        }
+      }
+    });
+
+    it('should initialize stars with y coordinates within canvas bounds', () => {
+      for (const layer of starfield.layers) {
+        for (const star of layer.stars) {
+          expect(star.y).toBeGreaterThanOrEqual(0);
+          expect(star.y).toBeLessThanOrEqual(GAME.HEIGHT);
+        }
+      }
+    });
+
+    it('should have x and y properties on each star', () => {
+      for (const layer of starfield.layers) {
+        for (const star of layer.stars) {
+          expect(star).toHaveProperty('x');
+          expect(star).toHaveProperty('y');
+          expect(typeof star.x).toBe('number');
+          expect(typeof star.y).toBe('number');
+        }
+      }
+    });
+  });
+
+  describe('update', () => {
+    it('should move stars downward when update is called', () => {
+      const layer = starfield.layers[0];
+      const star = layer.stars[0];
+      const initialY = star.y;
+      const deltaTime = 100; // milliseconds
+
+      starfield.update(deltaTime);
+
+      expect(star.y).toBeGreaterThan(initialY);
+    });
+
+    it('should move stars at correct speed based on layer speed multiplier', () => {
+      const deltaTime = 1000; // 1 second
+      const layer = starfield.layers[0];
+      const star = layer.stars[0];
+      const initialY = star.y;
+
+      starfield.update(deltaTime);
+
+      const expectedDeltaY = layer.speed * starfield.baseSpeed;
+      const actualDeltaY = star.y - initialY;
+      expect(actualDeltaY).toBeCloseTo(expectedDeltaY, 5);
+    });
+
+    it('should respect deltaTime conversion from milliseconds to seconds', () => {
+      const deltaTime = 500; // 0.5 seconds
+      const layer = starfield.layers[1];
+      const star = layer.stars[0];
+      const initialY = star.y;
+
+      starfield.update(deltaTime);
+
+      const expectedDeltaY = layer.speed * starfield.baseSpeed * 0.5;
+      const actualDeltaY = star.y - initialY;
+      expect(actualDeltaY).toBeCloseTo(expectedDeltaY, 5);
+    });
+
+    it('should wrap stars to top when they pass the bottom', () => {
+      const layer = starfield.layers[0];
+      const star = layer.stars[0];
+      star.y = GAME.HEIGHT - 5;
+
+      starfield.update(100);
+
+      expect(star.y).toBeLessThan(GAME.HEIGHT);
+    });
+
+    it('should position wrapped stars at negative y offset based on star size', () => {
+      const layer = starfield.layers[1];
+      const star = layer.stars[0];
+      star.y = GAME.HEIGHT;
+
+      starfield.update(1);
+
+      expect(star.y).toBeLessThanOrEqual(-layer.size);
+      expect(star.y).toBeGreaterThanOrEqual(-layer.size - 1);
+    });
+
+    it('should randomize x position when star wraps around', () => {
+      const layer = starfield.layers[2];
+      const star = layer.stars[0];
+      star.y = GAME.HEIGHT - 1;
+      const originalX = star.x;
+
+      // Mock Math.random to verify wrapping occurs
+      const randomSpy = vi.spyOn(Math, 'random');
+      randomSpy.mockReturnValue(0.5);
+
+      starfield.update(1000);
+
+      expect(star.x).toBe(GAME.WIDTH * 0.5);
+      expect(star.x).not.toBe(originalX);
+
+      randomSpy.mockRestore();
+    });
+
+    it('should update all layers simultaneously', () => {
+      // Set specific star positions to avoid wrap edge cases
+      for (const layer of starfield.layers) {
+        for (const star of layer.stars) {
+          star.y = 100; // Position well away from bottom edge
+        }
+      }
+
+      const initialPositions = starfield.layers.map(layer =>
+        layer.stars.map(star => ({ x: star.x, y: star.y }))
+      );
+
+      starfield.update(100);
+
+      // Each layer should move its stars downward
+      for (let layerIdx = 0; layerIdx < starfield.layers.length; layerIdx++) {
+        const layer = starfield.layers[layerIdx];
+        for (let starIdx = 0; starIdx < layer.stars.length; starIdx++) {
+          const star = layer.stars[starIdx];
+          const initialY = initialPositions[layerIdx][starIdx].y;
+          expect(star.y).toBeGreaterThan(initialY);
+        }
+      }
+    });
+
+    it('should handle zero deltaTime without errors', () => {
+      const layer = starfield.layers[0];
+      const star = layer.stars[0];
+      const initialY = star.y;
+
+      starfield.update(0);
+
+      expect(star.y).toBe(initialY);
+    });
+  });
+
+  describe('draw', () => {
+    it('should call fillRect for each star in all layers', () => {
+      starfield.draw(mockCtx);
+
+      const totalStars = starfield.layers.reduce((sum, layer) => sum + layer.stars.length, 0);
+      expect(mockCtx.fillRect).toHaveBeenCalledTimes(totalStars);
+    });
+
+    it('should set fillStyle to layer color before drawing', () => {
+      starfield.draw(mockCtx);
+
+      for (const layer of starfield.layers) {
+        expect(mockCtx.fillStyle).toHaveBeenCalledWith ||
+        expect([mockCtx.fillStyle]).toContain(layer.color);
+      }
+    });
+
+    it('should draw stars with correct size from layer config', () => {
+      starfield.draw(mockCtx);
+
+      let callIndex = 0;
+      for (const layer of starfield.layers) {
+        for (const star of layer.stars) {
+          const call = mockCtx.fillRect.mock.calls[callIndex];
+          const width = call[2];
+          const height = call[3];
+          expect(width).toBe(layer.size);
+          expect(height).toBe(layer.size);
+          callIndex++;
+        }
+      }
+    });
+
+    it('should round star coordinates when drawing', () => {
+      const layer = starfield.layers[0];
+      const star = layer.stars[0];
+      star.x = 123.7;
+      star.y = 456.3;
+
+      starfield.draw(mockCtx);
+
+      const call = mockCtx.fillRect.mock.calls[0];
+      expect(call[0]).toBe(Math.round(123.7));
+      expect(call[1]).toBe(Math.round(456.3));
+    });
+
+    it('should draw all stars from all layers', () => {
+      starfield.draw(mockCtx);
+
+      const expectedCalls = starfield.layers.reduce((sum, layer) => sum + layer.stars.length, 0);
+      expect(mockCtx.fillRect).toHaveBeenCalledTimes(expectedCalls);
+    });
+
+    it('should handle empty starfield gracefully', () => {
+      const emptyStarfield = new Starfield(GAME.WIDTH, GAME.HEIGHT);
+      emptyStarfield.layers.forEach(layer => layer.stars = []);
+
+      expect(() => emptyStarfield.draw(mockCtx)).not.toThrow();
+      expect(mockCtx.fillRect).not.toHaveBeenCalled();
+    });
+
+    it('should set correct fillStyle for each layer', () => {
+      mockCtx.fillStyle = '';
+      starfield.draw(mockCtx);
+
+      let layerIndex = 0;
+      for (const layer of starfield.layers) {
+        for (let i = 0; i < layer.stars.length; i++) {
+          if (i === 0) {
+            // Verify fillStyle was set to this layer's color at some point
+            expect(mockCtx.fillStyle).toBeDefined();
+          }
+        }
+        layerIndex++;
+      }
+    });
+  });
+
+  describe('custom dimensions', () => {
+    it('should accept custom width and height in constructor', () => {
+      const customWidth = 1024;
+      const customHeight = 768;
+      const customStarfield = new Starfield(customWidth, customHeight);
+
+      expect(customStarfield.width).toBe(customWidth);
+      expect(customStarfield.height).toBe(customHeight);
+    });
+
+    it('should initialize stars within custom canvas bounds', () => {
+      const customWidth = 640;
+      const customHeight = 480;
+      const customStarfield = new Starfield(customWidth, customHeight);
+
+      for (const layer of customStarfield.layers) {
+        for (const star of layer.stars) {
+          expect(star.x).toBeGreaterThanOrEqual(0);
+          expect(star.x).toBeLessThanOrEqual(customWidth);
+          expect(star.y).toBeGreaterThanOrEqual(0);
+          expect(star.y).toBeLessThanOrEqual(customHeight);
+        }
+      }
+    });
+
+    it('should wrap stars correctly with custom height', () => {
+      const customHeight = 300;
+      const customStarfield = new Starfield(GAME.WIDTH, customHeight);
+      const layer = customStarfield.layers[0];
+      const star = layer.stars[0];
+      star.y = customHeight - 1;
+
+      customStarfield.update(1000);
+
+      expect(star.y).toBeLessThan(customHeight);
+    });
+  });
+
+  describe('layer depth ordering', () => {
+    it('should maintain correct layer order for depth effect', () => {
+      expect(starfield.layers[0].speed).toBeLessThan(starfield.layers[1].speed);
+      expect(starfield.layers[1].speed).toBeLessThan(starfield.layers[2].speed);
+    });
+
+    it('should have smaller stars in back layers', () => {
+      expect(starfield.layers[0].size).toBeLessThan(starfield.layers[1].size);
+      expect(starfield.layers[1].size).toBeLessThan(starfield.layers[2].size);
+    });
+
+    it('should have darker colors in back layers', () => {
+      expect(starfield.layers[0].color).toBe('#444444'); // Darkest
+      expect(starfield.layers[1].color).toBe('#888888'); // Medium
+      expect(starfield.layers[2].color).toBe('#FFFFFF'); // Brightest
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a 3-layer parallax scrolling starfield background
- Stars appear behind all game elements (menu screen and gameplay)
- Creates depth effect with varying star sizes, brightness, and scroll speeds

Closes #2

## Implementation Details

### Files Added
| File | Description |
|------|-------------|
| `src/renderer/starfield.js` | Starfield class with parallax layers |
| `tests/renderer/starfield.test.js` | 30 unit tests |

### Files Modified
| File | Changes |
|------|---------|
| `src/constants.js` | Added STARFIELD configuration |
| `src/game.js` | Integrated starfield update/render |
| `src/renderer/canvas-renderer.js` | Removed canvas clear from start screen |

### Parallax Layers
| Layer | Stars | Size | Color | Speed |
|-------|-------|------|-------|-------|
| Far | 50 | 1px | #444444 | 0.2 |
| Mid | 40 | 2px | #888888 | 0.5 |
| Near | 30 | 3px | #FFFFFF | 1.0 |

## Test Plan
- [x] All 173 tests pass
- [x] Build succeeds
- [ ] Manual: Stars scroll smoothly at 60fps
- [ ] Manual: Starfield visible on start screen
- [ ] Manual: Starfield visible during gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)