### PR TITLE
fix: Resolve touch controls issues (coordinate scaling and case mismatch)

### DIFF
--- a/src/managers/touch-control-manager.js
+++ b/src/managers/touch-control-manager.js
@@ -6,8 +6,8 @@ import { GAME, TOUCH_CONTROLS } from '../constants.js';
  */
 export class TouchControlManager {
   constructor() {
-    // Device capability detection
-    this.touchSupported = 'ontouchstart' in window;
+    // Device capability detection - check both methods for better compatibility
+    this.touchSupported = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     this.enabled = false;
 
     // Track all active touches
@@ -197,7 +197,7 @@ export class TouchControlManager {
   }
 
   /**
-   * Get touch coordinates relative to canvas
+   * Get touch coordinates relative to canvas, accounting for CSS scaling
    * @param {Touch} touch
    * @returns {{x: number, y: number}}
    */
@@ -208,8 +208,15 @@ export class TouchControlManager {
     }
 
     const rect = gameCanvas.getBoundingClientRect();
-    const x = touch.clientX - rect.left;
-    const y = touch.clientY - rect.top;
+
+    // Calculate scale factors to account for CSS scaling
+    // When canvas is displayed at different size than internal resolution
+    const scaleX = gameCanvas.width / rect.width;
+    const scaleY = gameCanvas.height / rect.height;
+
+    // Get touch position relative to canvas, then scale to internal coordinates
+    const x = (touch.clientX - rect.left) * scaleX;
+    const y = (touch.clientY - rect.top) * scaleY;
 
     return { x, y };
   }
@@ -427,11 +434,16 @@ export class TouchControlManager {
   }
 
   /**
-   * Get button positions for rendering
-   * @returns {Object} Button position data
+   * Get button positions for rendering (lowercase keys for renderer compatibility)
+   * @returns {Object} Button position data with lowercase keys
    */
   getButtonPositions() {
-    return { ...this.buttonPositions };
+    return {
+      left: this.buttonPositions.LEFT,
+      right: this.buttonPositions.RIGHT,
+      fire: this.buttonPositions.FIRE,
+      pause: this.buttonPositions.PAUSE,
+    };
   }
 
   /**

--- a/tests/touch-controls.test.js
+++ b/tests/touch-controls.test.js
@@ -384,10 +384,10 @@ describe('TouchControlManager', () => {
       manager.start();
       const positions = manager.getButtonPositions();
 
-      expect(positions).toHaveProperty('LEFT');
-      expect(positions).toHaveProperty('RIGHT');
-      expect(positions).toHaveProperty('FIRE');
-      expect(positions).toHaveProperty('PAUSE');
+      expect(positions).toHaveProperty('left');
+      expect(positions).toHaveProperty('right');
+      expect(positions).toHaveProperty('fire');
+      expect(positions).toHaveProperty('pause');
     });
 
     it('should return object with correct position properties', () => {
@@ -411,39 +411,39 @@ describe('TouchControlManager', () => {
 
       expect(positions1).not.toBe(positions2);
       // Objects are equal but different instances
-      expect(positions1.LEFT).toEqual(positions2.LEFT);
+      expect(positions1.left).toEqual(positions2.left);
     });
 
-    it('should have LEFT button positioned at bottom-left', () => {
+    it('should have left button positioned at bottom-left', () => {
       manager.start();
       const positions = manager.getButtonPositions();
 
-      expect(positions.LEFT.x).toBeLessThan(GAME.WIDTH / 2);
-      expect(positions.LEFT.y).toBeGreaterThan(GAME.HEIGHT / 2);
+      expect(positions.left.x).toBeLessThan(GAME.WIDTH / 2);
+      expect(positions.left.y).toBeGreaterThan(GAME.HEIGHT / 2);
     });
 
-    it('should have RIGHT button positioned next to LEFT', () => {
+    it('should have right button positioned next to left', () => {
       manager.start();
       const positions = manager.getButtonPositions();
 
-      expect(positions.RIGHT.x).toBeGreaterThan(positions.LEFT.x);
-      expect(positions.RIGHT.y).toBe(positions.LEFT.y);
+      expect(positions.right.x).toBeGreaterThan(positions.left.x);
+      expect(positions.right.y).toBe(positions.left.y);
     });
 
-    it('should have FIRE button positioned at bottom-right', () => {
+    it('should have fire button positioned at bottom-right', () => {
       manager.start();
       const positions = manager.getButtonPositions();
 
-      expect(positions.FIRE.x).toBeGreaterThan(GAME.WIDTH / 2);
-      expect(positions.FIRE.y).toBeGreaterThan(GAME.HEIGHT / 2);
+      expect(positions.fire.x).toBeGreaterThan(GAME.WIDTH / 2);
+      expect(positions.fire.y).toBeGreaterThan(GAME.HEIGHT / 2);
     });
 
-    it('should have PAUSE button positioned at top-right', () => {
+    it('should have pause button positioned at top-right', () => {
       manager.start();
       const positions = manager.getButtonPositions();
 
-      expect(positions.PAUSE.x).toBeGreaterThan(GAME.WIDTH / 2);
-      expect(positions.PAUSE.y).toBeLessThan(GAME.HEIGHT / 2);
+      expect(positions.pause.x).toBeGreaterThan(GAME.WIDTH / 2);
+      expect(positions.pause.y).toBeLessThan(GAME.HEIGHT / 2);
     });
   });
 
@@ -506,7 +506,7 @@ describe('TouchControlManager', () => {
 
     it('should detect hit within button radius', () => {
       const positions = manager.getButtonPositions();
-      const leftPos = positions.LEFT;
+      const leftPos = positions.left;
 
       const touch = createTouch(leftPos.x, leftPos.y, 0);
       expect(manager.isPointInButton(touch.clientX - 0, touch.clientY - 0, leftPos)).toBe(true);
@@ -514,7 +514,7 @@ describe('TouchControlManager', () => {
 
     it('should not detect hit outside button radius', () => {
       const positions = manager.getButtonPositions();
-      const leftPos = positions.LEFT;
+      const leftPos = positions.left;
 
       const x = leftPos.x + leftPos.radius + 10;
       const y = leftPos.y;
@@ -523,7 +523,7 @@ describe('TouchControlManager', () => {
 
     it('should detect hit at button boundary', () => {
       const positions = manager.getButtonPositions();
-      const leftPos = positions.LEFT;
+      const leftPos = positions.left;
 
       const angle = Math.PI / 4;
       const x = leftPos.x + Math.cos(angle) * (leftPos.radius - 0.5);
@@ -533,7 +533,7 @@ describe('TouchControlManager', () => {
 
     it('should use circular hit detection', () => {
       const positions = manager.getButtonPositions();
-      const leftPos = positions.LEFT;
+      const leftPos = positions.left;
 
       // Point above button but within radius
       const x = leftPos.x;
@@ -742,13 +742,13 @@ describe('TouchControlManager', () => {
       manager.setCanvasDimensions(newWidth, newHeight);
       const newPositions = manager.getButtonPositions();
 
-      // LEFT button x should stay same (left offset is fixed)
-      expect(newPositions.LEFT.x).toBe(originalPositions.LEFT.x);
+      // left button x should stay same (left offset is fixed)
+      expect(newPositions.left.x).toBe(originalPositions.left.x);
       // But y changes with canvas height
-      expect(newPositions.LEFT.y).toBeGreaterThan(originalPositions.LEFT.y);
+      expect(newPositions.left.y).toBeGreaterThan(originalPositions.left.y);
 
-      // FIRE button x should be further right with wider screen
-      expect(newPositions.FIRE.x).toBeGreaterThan(originalPositions.FIRE.x);
+      // fire button x should be further right with wider screen
+      expect(newPositions.fire.x).toBeGreaterThan(originalPositions.fire.x);
     });
 
     it('should handle resize event', () => {
@@ -1116,10 +1116,10 @@ describe('InputHandler Touch Integration', () => {
       inputHandler.touchControls.start();
       const positions = inputHandler.getTouchButtonPositions();
 
-      expect(positions).toHaveProperty('LEFT');
-      expect(positions).toHaveProperty('RIGHT');
-      expect(positions).toHaveProperty('FIRE');
-      expect(positions).toHaveProperty('PAUSE');
+      expect(positions).toHaveProperty('left');
+      expect(positions).toHaveProperty('right');
+      expect(positions).toHaveProperty('fire');
+      expect(positions).toHaveProperty('pause');
     });
 
     it('should return same positions as touch manager', () => {
@@ -1328,25 +1328,17 @@ describe('Integration Scenarios', () => {
     const startEvent = createTouchEvent('touchstart', [touch]);
     manager.handleTouchStart(startEvent);
 
-    // Get positions and states from manager
-    const managerPositions = manager.getButtonPositions();
-    const managerStates = manager.getButtonStates();
-
-    // Convert to lowercase keys for renderer
-    const rendererPositions = {
-      left: managerPositions.LEFT,
-      right: managerPositions.RIGHT,
-      fire: managerPositions.FIRE,
-      pause: managerPositions.PAUSE,
-    };
+    // Get positions and states from manager (now returns lowercase keys)
+    const buttonPositions = manager.getButtonPositions();
+    const buttonStates = manager.getButtonStates();
 
     const drawSpy = vi.spyOn(renderer, 'drawLeftButton');
-    renderer.draw(mockCtx, rendererPositions, managerStates);
+    renderer.draw(mockCtx, buttonPositions, buttonStates);
 
     // Verify rendering was performed
     expect(drawSpy).toHaveBeenCalled();
     // Button should be rendered as pressed
-    expect(drawSpy).toHaveBeenCalledWith(mockCtx, rendererPositions.left, true);
+    expect(drawSpy).toHaveBeenCalledWith(mockCtx, buttonPositions.left, true);
   });
 
   it('should integrate touch with input handler', () => {


### PR DESCRIPTION
## Summary

Fixes #14

This PR resolves the critical bugs in the touch controls implementation that caused touch input to not work properly on mobile devices.

## Issues Fixed

| Issue | Description | Fix |
|-------|-------------|-----|
| **Touch Detection** | Used only `ontouchstart in window` | Now also checks `navigator.maxTouchPoints > 0` |
| **Canvas Scaling** | Touch coordinates didn't account for CSS scaling | Added `scaleX`/`scaleY` transformation |
| **Case Mismatch** | `getButtonPositions()` returned `LEFT`, `RIGHT`, etc. but renderer expected `left`, `right`, etc. | Changed to lowercase keys |

## Technical Details

### Canvas Scaling Fix

When the canvas is displayed at a different size than its internal resolution (e.g., on mobile where CSS sets `width: 100vw`), touch coordinates must be scaled:

```javascript
// Before (broken)
const x = touch.clientX - rect.left;
const y = touch.clientY - rect.top;

// After (fixed)
const scaleX = gameCanvas.width / rect.width;
const scaleY = gameCanvas.height / rect.height;
const x = (touch.clientX - rect.left) * scaleX;
const y = (touch.clientY - rect.top) * scaleY;
```

### Case Mismatch Fix

```javascript
// Before (returned uppercase keys)
return { ...this.buttonPositions }; // { LEFT: {...}, RIGHT: {...}, ... }

// After (returns lowercase keys to match renderer)
return {
  left: this.buttonPositions.LEFT,
  right: this.buttonPositions.RIGHT,
  fire: this.buttonPositions.FIRE,
  pause: this.buttonPositions.PAUSE,
};
```

## Test Plan

- [x] All 441 tests pass
- [x] Build succeeds (77.68 KB)
- [ ] Manual testing on mobile device
- [ ] Verify touch buttons respond correctly
- [ ] Verify multi-touch (move + fire) works
- [ ] Test on both iOS and Android

## References

- [MDN: Mobile touch controls](https://developer.mozilla.org/en-US/docs/Games/Techniques/Control_mechanisms/Mobile_touch)
- [BrowserStack: Viewport responsive](https://www.browserstack.com/guide/viewport-responsive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)