### PR TITLE
feat: Combo system with score multipliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm run dev
 - 🕹️ **Classic Mode**: Authentic Space Invaders mechanics with 5 levels
 - ♾️ **Endless Mode**: Infinite waves with progressive difficulty scaling
 - ⚡ **Power-ups**: Collect shields, rapid fire, multi-shot, bombs, and extra lives
+- 🔥 **Combo System**: Chain kills for score multipliers up to 3x
 - 🏆 **Leaderboard**: Top 10 high scores with classic 3-letter initials entry
 - 🎮 **Controller Support**: Full gamepad support (Xbox, PlayStation, Nintendo, generic)
 
@@ -191,6 +192,30 @@ Fully synthesized chiptune music plays throughout the game, with different track
 - Independent from SFX mute (M key mutes both)
 - Automatically pauses when game is paused
 - Multi-voice synthesis (square, triangle, sawtooth waves)
+
+### Combo System 🔥
+
+Build combos by destroying enemies in quick succession for bonus score multipliers!
+
+| Combo | Multiplier | Notes |
+|-------|------------|-------|
+| 2x | ×1.5 | First milestone |
+| 3x | ×2.0 | Rising tone plays |
+| 4x | ×2.5 | Getting intense! |
+| 5x+ | ×3.0 | Maximum multiplier |
+
+**Mechanics:**
+- **Timing Window**: 1.5 seconds between kills, +200ms grace per kill
+- **Combo Display**: Shows "3x COMBO! (×2.0)" in HUD during active combo
+- **Floating Popups**: Yellow popup at kill location shows combo count
+- **Combo Broken**: Red "COMBO BROKEN" popup when combo expires
+- **Sound Effects**: Rising arpeggio at milestones (2, 3, 5, 10, 15, 20...)
+- **Max Combo Tracking**: Your best combo is saved with high scores
+
+**Tips:**
+- Focus on enemies in clusters for easier chains
+- Multi-shot power-up makes combos easier to build
+- Higher combos mean exponentially more points!
 
 ## 🏗️ Project Structure
 
@@ -405,11 +430,12 @@ See [Game Modes](#-game-modes) for details on how to use these features.
 | **Power-ups System** | ✅ Done | Shield, rapid fire, multi-shot, bomb, extra life - dropped by enemies |
 | **Touch Controls** | ✅ Done | On-screen virtual buttons for mobile play with haptic feedback |
 | **Background Music** | ✅ Done | 5 chiptune tracks (title, battle, boss, victory, game over) |
-| **Combo System** | ⬜ Todo | Bonus points for destroying enemies in quick succession |
+| **Combo System** | ✅ Done | Chain kills for ×1.5 to ×3.0 score multipliers |
 | **Wave/Formation Patterns** | ⬜ Todo | Different enemy formations per level (V-shape, diamond, spiral) |
 
 See [Touch (Mobile)](#touch-mobile-) controls for details on touch controls.
 See [Background Music](#background-music-) for details on the music system.
+See [Combo System](#combo-system-) for details on combo mechanics.
 
 ### Phase 3: Visual & Audio Polish (4+ hours each)
 

--- a/src/audio/sound-manager.js
+++ b/src/audio/sound-manager.js
@@ -474,4 +474,72 @@ export class SoundManager {
     osc.start();
     osc.stop(this.audioContext.currentTime + 1);
   }
+
+  /**
+   * Play combo milestone sound based on combo count
+   * @param {number} comboCount - The current combo count
+   */
+  playComboMilestone(comboCount) {
+    if (!this.initialized || this.muted) return;
+
+    const osc = this.audioContext.createOscillator();
+    const gain = this.audioContext.createGain();
+
+    osc.type = 'square';
+    gain.gain.setValueAtTime(0.25, this.audioContext.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.01, this.audioContext.currentTime + 0.25);
+
+    osc.connect(gain);
+    gain.connect(this.masterGain);
+
+    let notes = [];
+
+    if (comboCount === 2) {
+      // 2x combo: Quick rising arpeggio (C4 → E4 → G4)
+      notes = [261.63, 329.63, 392]; // C4, E4, G4
+    } else if (comboCount === 3) {
+      // 3x combo: Higher arpeggio (E4 → G4 → C5)
+      notes = [329.63, 392, 523.25]; // E4, G4, C5
+    } else if (comboCount >= 5) {
+      // 5x+ combo: Full chord blast with layered square waves
+      // Play a C major chord (C E G) simultaneously by rapid alternation
+      notes = [261.63, 329.63, 392, 261.63, 329.63, 392]; // C4 E4 G4 repeated twice
+    }
+
+    if (notes.length > 0) {
+      let time = this.audioContext.currentTime;
+      const noteDuration = 0.05; // 50ms per note
+
+      for (const note of notes) {
+        osc.frequency.setValueAtTime(note, time);
+        time += noteDuration;
+      }
+
+      osc.start();
+      osc.stop(this.audioContext.currentTime + (notes.length * noteDuration));
+    }
+  }
+
+  /**
+   * Play combo broken sound - descending "womp womp"
+   */
+  playComboBroken() {
+    if (!this.initialized || this.muted) return;
+
+    const osc = this.audioContext.createOscillator();
+    const gain = this.audioContext.createGain();
+
+    osc.type = 'square';
+    osc.frequency.setValueAtTime(261.63, this.audioContext.currentTime); // C4
+    osc.frequency.exponentialRampToValueAtTime(196, this.audioContext.currentTime + 0.2); // G3
+
+    gain.gain.setValueAtTime(0.3, this.audioContext.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.01, this.audioContext.currentTime + 0.2);
+
+    osc.connect(gain);
+    gain.connect(this.masterGain);
+
+    osc.start();
+    osc.stop(this.audioContext.currentTime + 0.2);
+  }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -190,6 +190,40 @@ export const POWERUPS = {
   },
 };
 
+/**
+ * Combo system configuration
+ * Tracks consecutive enemy kills and applies multipliers to score
+ */
+export const COMBO = {
+  TIMEOUT: 1500,         // ms before combo resets
+  GRACE_PERIOD: 200,     // ms added per kill
+  MAX_MULTIPLIER: 3.0,   // Cap at 3x
+  MULTIPLIERS: {
+    2: 1.5,
+    3: 2.0,
+    4: 2.5,
+    5: 3.0,  // 5+ stays at 3.0
+  },
+  POPUP: {
+    DURATION: 1000,      // How long popup shows
+    RISE_SPEED: 1.5,     // Pixels per frame
+    FADE_START: 0.7,     // Start fading at 70% through duration
+    FONT_SIZE: 24,
+    COLOR: '#FFFF00',    // Yellow for combo messages
+    BROKEN_COLOR: '#FF4444', // Red for "COMBO BROKEN"
+  },
+  EFFECTS: {
+    SCREEN_SHAKE: false,  // Shake on 5x combo?
+    COLOR_FLASH: true,    // Flash combo counter color
+  },
+  SOUNDS: {
+    COMBO_2: true,        // Play sound at 2x combo
+    COMBO_3: true,        // Play sound at 3x combo
+    COMBO_5: true,        // Play sound at 5x combo
+    BROKEN: true,         // Play sound when combo breaks
+  },
+};
+
 export const Keys = {
   LEFT: ['ArrowLeft', 'KeyA'],
   RIGHT: ['ArrowRight', 'KeyD'],

--- a/src/game.js
+++ b/src/game.js
@@ -1,4 +1,4 @@
-import { GAME, GameState, GameMode, BUNKER, MYSTERY_SHIP, ENDLESS_MODE, POWERUPS, MUSIC } from './constants.js';
+import { GAME, GameState, GameMode, BUNKER, MYSTERY_SHIP, ENDLESS_MODE, POWERUPS, MUSIC, COMBO } from './constants.js';
 import { CanvasRenderer } from './renderer/canvas-renderer.js';
 import { Starfield } from './renderer/starfield.js';
 import { TouchControlsRenderer } from './renderer/touch-controls-renderer.js';
@@ -9,6 +9,8 @@ import { CollisionDetector } from './managers/collision-detector.js';
 import { ScoreManager } from './managers/score-manager.js';
 import { NameEntryManager } from './managers/name-entry-manager.js';
 import { PowerUpManager } from './managers/power-up-manager.js';
+import { ComboManager } from './managers/combo-manager.js';
+import { PopupManager } from './managers/popup-manager.js';
 import { SoundManager } from './audio/sound-manager.js';
 import { MusicManager } from './audio/music-manager.js';
 import { Player } from './entities/player.js';
@@ -31,6 +33,8 @@ export class Game {
     this.scoreManager = new ScoreManager();
     this.nameEntryManager = new NameEntryManager();
     this.powerUpManager = new PowerUpManager();
+    this.comboManager = new ComboManager();
+    this.popupManager = new PopupManager();
     this.soundManager = new SoundManager();
     this.musicManager = null; // Initialized after soundManager.init()
 
@@ -261,6 +265,19 @@ export class Game {
     // Update screen shake
     this.renderer.updateShake(deltaTime);
 
+    // Update combo system (check if combo expired)
+    const comboResult = this.comboManager.update(performance.now());
+    if (comboResult.comboBroken && comboResult.previousCount >= 2) {
+      // Combo broken - show popup and play sound
+      this.popupManager.addComboBrokenPopup(comboResult.previousCount, GAME.WIDTH / 2, GAME.HEIGHT / 2);
+      if (COMBO.SOUNDS.BROKEN) {
+        this.soundManager.playComboBroken();
+      }
+    }
+
+    // Update popups
+    this.popupManager.update(deltaTime);
+
     // Check collisions
     this.checkCollisions();
 
@@ -456,11 +473,32 @@ export class Game {
     );
     for (const { projectile, enemy } of enemyHits) {
       projectile.deactivate();
-      const points = this.enemyManager.removeEnemy(enemy);
+      const basePoints = this.enemyManager.removeEnemy(enemy);
       const enemyCenterX = enemy.x + enemy.width / 2;
       const enemyCenterY = enemy.y + enemy.height / 2;
       this.addExplosion(enemyCenterX, enemyCenterY);
       this.soundManager.playExplosion();
+
+      // Register kill with combo system
+      const comboState = this.comboManager.registerKill(performance.now());
+
+      // Apply combo multiplier to points
+      const points = Math.floor(basePoints * comboState.multiplier);
+
+      // Show combo popup on milestone
+      if (comboState.isMilestone && comboState.comboCount >= 2) {
+        this.popupManager.addComboPopup(comboState.comboCount, enemyCenterX, enemyCenterY - 20);
+
+        // Play combo milestone sound
+        if ((comboState.comboCount === 2 && COMBO.SOUNDS.COMBO_2) ||
+            (comboState.comboCount === 3 && COMBO.SOUNDS.COMBO_3) ||
+            (comboState.comboCount >= 5 && COMBO.SOUNDS.COMBO_5)) {
+          this.soundManager.playComboMilestone(comboState.comboCount);
+        }
+      }
+
+      // Update max combo in score manager
+      this.scoreManager.setMaxCombo(this.comboManager.getMaxCombo());
 
       // Try to spawn a power-up at enemy location
       if (this.powerUpManager.trySpawn(enemyCenterX, enemyCenterY)) {
@@ -631,6 +669,8 @@ export class Game {
     this.scoreManager.reset();
     this.projectileManager.clear();
     this.powerUpManager.reset();
+    this.comboManager.reset();
+    this.popupManager.reset();
     this.explosions = [];
     this.mysteryShip = null;
     this.mysteryShipTimer = 0;
@@ -937,13 +977,18 @@ export class Game {
 
     // Draw HUD with controller status (different for classic vs endless mode)
     const controllerStatus = this.input.getControllerStatus();
+    const comboCount = this.comboManager.getCount();
+    const comboMultiplier = this.comboManager.getMultiplier();
+
     if (this.gameMode === GameMode.ENDLESS) {
       this.renderer.drawHUDEndless(
         this.scoreManager.getScore(),
         this.scoreManager.getHighScore(),
         this.player.lives,
         this.wave,
-        controllerStatus
+        controllerStatus,
+        comboCount,
+        comboMultiplier
       );
     } else {
       this.renderer.drawHUD(
@@ -951,13 +996,18 @@ export class Game {
         this.scoreManager.getHighScore(),
         this.player.lives,
         this.level,
-        controllerStatus
+        controllerStatus,
+        comboCount,
+        comboMultiplier
       );
     }
 
     // Draw power-up HUD (active effects with countdown timers)
     const activeEffects = this.powerUpManager.getActiveEffectsStatus(this.lastTime);
     this.renderer.drawPowerUpHUD(activeEffects);
+
+    // Draw combo popups
+    this.renderer.drawPopups(this.popupManager.getPopups());
 
     // Draw touch controls overlay (on touch devices)
     this.drawTouchControls(ctx);

--- a/src/managers/combo-manager.js
+++ b/src/managers/combo-manager.js
@@ -1,0 +1,205 @@
+import { COMBO } from '../constants.js';
+
+/**
+ * Combo state object returned from registerKill
+ * @typedef {Object} ComboState
+ * @property {number} comboCount - Current combo count
+ * @property {number} multiplier - Current score multiplier
+ * @property {boolean} isNewCombo - True if this kill started a new combo
+ * @property {boolean} isMilestone - True if this count is a milestone
+ */
+
+/**
+ * Combo update result
+ * @typedef {Object} ComboUpdateResult
+ * @property {boolean} comboBroken - True if combo expired
+ * @property {number} previousCount - The combo count before update (0 if not broken)
+ */
+
+/**
+ * Manages the combo system for consecutive enemy kills
+ * Tracks combo count, multipliers, and milestones for scoring
+ */
+export class ComboManager {
+  /**
+   * Initialize combo manager state
+   */
+  constructor() {
+    this.count = 0;
+    this.multiplier = 1.0;
+    this.lastKillTime = null;
+    this.maxCombo = 0;
+    this._isActive = false;
+    this.accumulatedGrace = 0;
+  }
+
+  /**
+   * Register an enemy kill and update combo state
+   * @param {number} timestamp - Current timestamp (ms) from performance.now()
+   * @returns {ComboState} Updated combo state
+   */
+  registerKill(timestamp) {
+    let isNewCombo = false;
+
+    // Check if combo should continue or reset
+    if (this.lastKillTime === null) {
+      // First kill
+      this.count = 1;
+      isNewCombo = true;
+      this.accumulatedGrace = 0;
+    } else {
+      const timeSinceLastKill = timestamp - this.lastKillTime;
+      const comboTimeout = COMBO.TIMEOUT + this.accumulatedGrace;
+
+      if (timeSinceLastKill < comboTimeout) {
+        // Continue combo
+        this.count += 1;
+      } else {
+        // Combo expired, start new
+        this.count = 1;
+        isNewCombo = true;
+        this.accumulatedGrace = 0;
+      }
+    }
+
+    // Update last kill time
+    this.lastKillTime = timestamp;
+
+    // Add grace period for next kill
+    this.accumulatedGrace += COMBO.GRACE_PERIOD;
+
+    // Update multiplier
+    this.multiplier = this.calculateMultiplier();
+
+    // Update active state
+    this._isActive = this.count >= 2;
+
+    // Track max combo
+    if (this.count > this.maxCombo) {
+      this.maxCombo = this.count;
+    }
+
+    // Check if this is a milestone
+    const isMilestone = this.isMilestoneCount(this.count);
+
+    return {
+      comboCount: this.count,
+      multiplier: this.multiplier,
+      isNewCombo,
+      isMilestone,
+    };
+  }
+
+  /**
+   * Update combo state, checking if it has expired
+   * @param {number} timestamp - Current timestamp (ms) from performance.now()
+   * @returns {ComboUpdateResult} Result indicating if combo was broken
+   */
+  update(timestamp) {
+    const previousCount = this.count;
+    let comboBroken = false;
+
+    // Check if combo has expired
+    if (this.lastKillTime !== null && this.count > 0) {
+      const timeSinceLastKill = timestamp - this.lastKillTime;
+      const comboTimeout = COMBO.TIMEOUT + this.accumulatedGrace;
+
+      if (timeSinceLastKill >= comboTimeout) {
+        // Combo expired
+        this.count = 0;
+        this.multiplier = 1.0;
+        this._isActive = false;
+        this.accumulatedGrace = 0;
+        comboBroken = previousCount > 0;
+      }
+    }
+
+    return {
+      comboBroken,
+      previousCount: comboBroken ? previousCount : 0,
+    };
+  }
+
+  /**
+   * Calculate the multiplier based on current combo count
+   * @returns {number} Current score multiplier (min 1.0, max COMBO.MAX_MULTIPLIER)
+   */
+  calculateMultiplier() {
+    if (this.count < 2) {
+      return 1.0;
+    }
+
+    // Check for exact multiplier values
+    if (COMBO.MULTIPLIERS[this.count]) {
+      return COMBO.MULTIPLIERS[this.count];
+    }
+
+    // For counts beyond the defined multipliers, use max
+    return COMBO.MULTIPLIERS[5] || COMBO.MAX_MULTIPLIER;
+  }
+
+  /**
+   * Check if a combo count is a milestone (2, 3, 5, 10, 15, 20, etc.)
+   * @param {number} count
+   * @returns {boolean}
+   */
+  isMilestoneCount(count) {
+    if (count < 2) return false;
+
+    // Milestones: 2, 3, 5, 10, 15, 20, 25, 30, ...
+    if (count === 2 || count === 3 || count === 5) {
+      return true;
+    }
+
+    // Every 5 kills after 5
+    if (count >= 10 && count % 5 === 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the current multiplier value
+   * @returns {number}
+   */
+  getMultiplier() {
+    return this.multiplier;
+  }
+
+  /**
+   * Get the current combo count
+   * @returns {number}
+   */
+  getCount() {
+    return this.count;
+  }
+
+  /**
+   * Get the maximum combo achieved in this game session
+   * @returns {number}
+   */
+  getMaxCombo() {
+    return this.maxCombo;
+  }
+
+  /**
+   * Check if combo is currently active (count >= 2)
+   * @returns {boolean}
+   */
+  isActive() {
+    return this._isActive;
+  }
+
+  /**
+   * Reset combo system for new game
+   */
+  reset() {
+    this.count = 0;
+    this.multiplier = 1.0;
+    this.lastKillTime = null;
+    this.maxCombo = 0;
+    this._isActive = false;
+    this.accumulatedGrace = 0;
+  }
+}

--- a/src/managers/popup-manager.js
+++ b/src/managers/popup-manager.js
@@ -1,0 +1,140 @@
+import { COMBO } from '../constants.js';
+
+/**
+ * PopupManager
+ * Manages temporary on-screen text popups like "3x COMBO!" and "COMBO BROKEN!"
+ * Popups rise upward, fade out over time, and are automatically removed when expired
+ */
+export class PopupManager {
+  /**
+   * Initialize empty popups array
+   */
+  constructor() {
+    this.popups = [];
+  }
+
+  /**
+   * Add a new popup to the display
+   * @param {string} text - The text to display
+   * @param {number} x - X position of the popup
+   * @param {number} y - Y position of the popup
+   * @param {string} color - Color of the text (hex string)
+   * @param {number} duration - How long the popup stays visible in ms (default: COMBO.POPUP.DURATION)
+   * @param {number} fontSize - Size of the text (default: COMBO.POPUP.FONT_SIZE)
+   */
+  add(
+    text,
+    x,
+    y,
+    color,
+    duration = COMBO.POPUP.DURATION,
+    fontSize = COMBO.POPUP.FONT_SIZE
+  ) {
+    const popup = {
+      text,
+      x,
+      y,
+      color,
+      createdAt: Date.now(),
+      duration,
+      fontSize,
+      opacity: 1.0,
+      velocityY: -COMBO.POPUP.RISE_SPEED,
+    };
+
+    this.popups.push(popup);
+  }
+
+  /**
+   * Add a combo popup with formatted text like "3x COMBO!"
+   * Displays the combo count and multiplier
+   * @param {number} comboCount - The current combo count
+   * @param {number} x - X position of the popup
+   * @param {number} y - Y position of the popup
+   */
+  addComboPopup(comboCount, x, y) {
+    const text = `${comboCount}x COMBO!`;
+    this.add(
+      text,
+      x,
+      y,
+      COMBO.POPUP.COLOR,
+      COMBO.POPUP.DURATION,
+      COMBO.POPUP.FONT_SIZE
+    );
+  }
+
+  /**
+   * Add a combo broken popup if the previous combo was >= 2
+   * Displays red "COMBO BROKEN" text
+   * @param {number} previousCount - The combo count before it was broken
+   * @param {number} x - X position of the popup
+   * @param {number} y - Y position of the popup
+   */
+  addComboBrokenPopup(previousCount, x, y) {
+    // Only show combo broken if there was a meaningful combo
+    if (previousCount >= 2) {
+      this.add(
+        'COMBO BROKEN',
+        x,
+        y,
+        COMBO.POPUP.BROKEN_COLOR,
+        COMBO.POPUP.DURATION,
+        COMBO.POPUP.FONT_SIZE
+      );
+    }
+  }
+
+  /**
+   * Update all popups (rise upward, fade out, remove expired)
+   * @param {number} deltaTime - Time elapsed since last update in milliseconds
+   */
+  update(deltaTime) {
+    // Update each popup
+    for (let i = this.popups.length - 1; i >= 0; i--) {
+      const popup = this.popups[i];
+      const elapsedTime = Date.now() - popup.createdAt;
+      const progress = elapsedTime / popup.duration;
+
+      // Update vertical position (rise upward)
+      popup.y += popup.velocityY;
+
+      // Calculate opacity (fade out after FADE_START of duration)
+      if (progress >= COMBO.POPUP.FADE_START) {
+        const fadeProgress =
+          (progress - COMBO.POPUP.FADE_START) /
+          (1 - COMBO.POPUP.FADE_START);
+        popup.opacity = Math.max(0, 1.0 - fadeProgress);
+      } else {
+        popup.opacity = 1.0;
+      }
+
+      // Remove popup if duration has elapsed
+      if (elapsedTime >= popup.duration) {
+        this.popups.splice(i, 1);
+      }
+    }
+  }
+
+  /**
+   * Get array of active popups for rendering
+   * @returns {Array} Array of popup objects
+   */
+  getPopups() {
+    return this.popups;
+  }
+
+  /**
+   * Remove all popups
+   */
+  clear() {
+    this.popups = [];
+  }
+
+  /**
+   * Alias for clear() - remove all popups
+   */
+  reset() {
+    this.clear();
+  }
+}

--- a/src/managers/score-manager.js
+++ b/src/managers/score-manager.js
@@ -25,6 +25,7 @@ export class ScoreManager {
     this.extraLivesAwarded = 0;
     this.gameMode = 'classic';
     this.wave = 1;
+    this.maxCombo = 0;
 
     // Load high scores (array of entries) and legacy high score
     this.highScores = this.loadHighScores();
@@ -208,6 +209,24 @@ export class ScoreManager {
   }
 
   /**
+   * Update maximum combo if the new value is higher
+   * @param {number} combo
+   */
+  setMaxCombo(combo) {
+    if (combo > this.maxCombo) {
+      this.maxCombo = combo;
+    }
+  }
+
+  /**
+   * Get maximum combo achieved
+   * @returns {number}
+   */
+  getMaxCombo() {
+    return this.maxCombo;
+  }
+
+  /**
    * Check if current score qualifies for high score board
    * @returns {boolean}
    */
@@ -250,6 +269,7 @@ export class ScoreManager {
     const entry = {
       initials: initials.toUpperCase().substring(0, 3),
       score: this.score,
+      maxCombo: this.maxCombo,
       timestamp: Date.now(),
     };
 
@@ -306,6 +326,7 @@ export class ScoreManager {
     this.level = 1;
     this.wave = 1;
     this.extraLivesAwarded = 0;
+    this.maxCombo = 0;
   }
 
   /**

--- a/src/renderer/canvas-renderer.js
+++ b/src/renderer/canvas-renderer.js
@@ -74,8 +74,10 @@ export class CanvasRenderer {
    * @param {number} lives - Player lives
    * @param {number} level - Current level
    * @param {Object} [controllerStatus] - Controller connection status
+   * @param {number} [comboCount=0] - Current combo count
+   * @param {number} [multiplier=1.0] - Score multiplier
    */
-  drawHUD(score, highScore, lives, level, controllerStatus = null) {
+  drawHUD(score, highScore, lives, level, controllerStatus = null, comboCount = 0, multiplier = 1.0) {
     this.ctx.fillStyle = UI.TEXT_COLOR;
     this.ctx.font = `${UI.FONT_SIZE}px ${UI.FONT_FAMILY}`;
 
@@ -94,6 +96,11 @@ export class CanvasRenderer {
     // Draw life icons
     for (let i = 0; i < lives; i++) {
       this.drawLifeIcon(UI.LIVES_X + 100 + i * 30, UI.LIVES_Y - 15);
+    }
+
+    // Draw combo HUD if active
+    if (comboCount >= 2) {
+      this.drawComboHUD(comboCount, multiplier, true);
     }
 
     // Controller indicator (bottom right)
@@ -745,8 +752,10 @@ export class CanvasRenderer {
    * @param {number} lives - Player lives
    * @param {number} wave - Current wave
    * @param {Object} [controllerStatus] - Controller connection status
+   * @param {number} [comboCount=0] - Current combo count
+   * @param {number} [multiplier=1.0] - Score multiplier
    */
-  drawHUDEndless(score, highScore, lives, wave, controllerStatus = null) {
+  drawHUDEndless(score, highScore, lives, wave, controllerStatus = null, comboCount = 0, multiplier = 1.0) {
     this.ctx.fillStyle = UI.TEXT_COLOR;
     this.ctx.font = `${UI.FONT_SIZE}px ${UI.FONT_FAMILY}`;
 
@@ -776,6 +785,11 @@ export class CanvasRenderer {
     // Draw life icons
     for (let i = 0; i < lives; i++) {
       this.drawLifeIcon(UI.LIVES_X + 100 + i * 30, UI.LIVES_Y - 15);
+    }
+
+    // Draw combo HUD if active
+    if (comboCount >= 2) {
+      this.drawComboHUD(comboCount, multiplier, true);
     }
 
     // Controller indicator (bottom right)
@@ -1060,6 +1074,65 @@ export class CanvasRenderer {
     this.ctx.stroke();
 
     this.ctx.restore();
+  }
+
+  /**
+   * Draw combo HUD display on the right side
+   * @param {number} comboCount - Number of consecutive hits
+   * @param {number} multiplier - Score multiplier (e.g., 1.5, 2.0)
+   * @param {boolean} isActive - Whether combo is currently active
+   */
+  drawComboHUD(comboCount, multiplier, isActive) {
+    if (!isActive || comboCount < 2) return;
+
+    const x = GAME.WIDTH - 180;
+    const y = UI.SCORE_Y;
+
+    this.ctx.fillStyle = '#FFFF00';
+    this.ctx.font = `${UI.FONT_SIZE}px ${UI.FONT_FAMILY}`;
+
+    // Format: "COMBO: 3x (×2.0)"
+    const comboText = `COMBO: ${comboCount}x (×${multiplier.toFixed(1)})`;
+    this.ctx.fillText(comboText, x, y);
+
+    // Subtle scale animation when combo changes
+    const scale = 1 + Math.sin(Date.now() / 150) * 0.05;
+    this.ctx.save();
+    this.ctx.translate(x + comboText.length * 3, y - 5);
+    this.ctx.scale(scale, scale);
+    this.ctx.fillStyle = '#FFFF00';
+    this.ctx.font = `14px ${UI.FONT_FAMILY}`;
+    this.ctx.fillText('!', 0, 0);
+    this.ctx.restore();
+  }
+
+  /**
+   * Draw array of floating popup messages
+   * @param {Array<{text: string, x: number, y: number, color: string, opacity: number, fontSize: number}>} popups
+   */
+  drawPopups(popups) {
+    if (!popups || popups.length === 0) return;
+
+    for (const popup of popups) {
+      this.ctx.save();
+
+      // Set opacity
+      this.ctx.globalAlpha = popup.opacity;
+
+      // Set text properties
+      this.ctx.fillStyle = popup.color;
+      this.ctx.font = `${popup.fontSize}px ${UI.FONT_FAMILY}`;
+      this.ctx.textAlign = 'center';
+      this.ctx.textBaseline = 'middle';
+
+      // Draw text centered at position
+      this.ctx.fillText(popup.text, popup.x, popup.y);
+
+      this.ctx.restore();
+    }
+
+    // Ensure globalAlpha is reset
+    this.ctx.globalAlpha = 1.0;
   }
 
   /**

--- a/tests/combo-system.test.js
+++ b/tests/combo-system.test.js
@@ -1,0 +1,1161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ComboManager } from '../src/managers/combo-manager.js';
+import { PopupManager } from '../src/managers/popup-manager.js';
+import { COMBO } from '../src/constants.js';
+
+describe('ComboManager', () => {
+  let comboManager;
+
+  beforeEach(() => {
+    comboManager = new ComboManager();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('Constructor initializes state correctly', () => {
+    it('should initialize count to 0', () => {
+      expect(comboManager.count).toBe(0);
+    });
+
+    it('should initialize multiplier to 1.0', () => {
+      expect(comboManager.multiplier).toBe(1.0);
+    });
+
+    it('should initialize lastKillTime to null', () => {
+      expect(comboManager.lastKillTime).toBeNull();
+    });
+
+    it('should initialize maxCombo to 0', () => {
+      expect(comboManager.maxCombo).toBe(0);
+    });
+
+    it('should initialize _isActive to false', () => {
+      expect(comboManager._isActive).toBe(false);
+    });
+
+    it('should initialize accumulatedGrace to 0', () => {
+      expect(comboManager.accumulatedGrace).toBe(0);
+    });
+  });
+
+  describe('First kill starts combo at 1 with multiplier 1.0', () => {
+    it('should set count to 1 on first kill', () => {
+      const result = comboManager.registerKill(Date.now());
+      expect(comboManager.count).toBe(1);
+      expect(result.comboCount).toBe(1);
+    });
+
+    it('should set isNewCombo to true for first kill', () => {
+      const result = comboManager.registerKill(Date.now());
+      expect(result.isNewCombo).toBe(true);
+    });
+
+    it('should keep multiplier at 1.0 for single kill', () => {
+      comboManager.registerKill(Date.now());
+      expect(comboManager.multiplier).toBe(1.0);
+      expect(comboManager.getMultiplier()).toBe(1.0);
+    });
+
+    it('should update lastKillTime on first kill', () => {
+      const now = Date.now();
+      comboManager.registerKill(now);
+      expect(comboManager.lastKillTime).toBe(now);
+    });
+
+    it('should add grace period after first kill', () => {
+      comboManager.registerKill(Date.now());
+      expect(comboManager.accumulatedGrace).toBe(COMBO.GRACE_PERIOD);
+    });
+  });
+
+  describe('Quick consecutive kills increment combo', () => {
+    it('should increment count from 1 to 2 on quick second kill', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      const result = comboManager.registerKill(Date.now());
+      expect(comboManager.count).toBe(2);
+      expect(result.comboCount).toBe(2);
+    });
+
+    it('should not mark second kill as new combo', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      const result = comboManager.registerKill(Date.now());
+      expect(result.isNewCombo).toBe(false);
+    });
+
+    it('should increment count from 2 to 3', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      const result = comboManager.registerKill(Date.now());
+      expect(comboManager.count).toBe(3);
+      expect(result.comboCount).toBe(3);
+    });
+
+    it('should accumulate grace periods', () => {
+      comboManager.registerKill(Date.now());
+      expect(comboManager.accumulatedGrace).toBe(COMBO.GRACE_PERIOD);
+
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      expect(comboManager.accumulatedGrace).toBe(COMBO.GRACE_PERIOD * 2);
+
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      expect(comboManager.accumulatedGrace).toBe(COMBO.GRACE_PERIOD * 3);
+    });
+
+    it('should continue combo for 5 consecutive rapid kills', () => {
+      for (let i = 1; i <= 5; i++) {
+        comboManager.registerKill(Date.now());
+        expect(comboManager.count).toBe(i);
+        vi.advanceTimersByTime(100);
+      }
+    });
+  });
+
+  describe('Combo resets after timeout', () => {
+    it('should reset combo when kill exceeds timeout', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      expect(comboManager.count).toBe(1);
+      // accumulatedGrace = GRACE_PERIOD = 200
+
+      // Jump past timeout window (TIMEOUT + grace)
+      // Timeout = 1500 + 200 = 1700
+      vi.advanceTimersByTime(COMBO.TIMEOUT + COMBO.GRACE_PERIOD + 1);
+      const result = comboManager.registerKill(Date.now());
+
+      expect(comboManager.count).toBe(1);
+      expect(result.isNewCombo).toBe(true);
+    });
+
+    it('should reset multiplier when combo times out', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      comboManager.registerKill(killTime2); // count = 2, multiplier should be 1.5
+      expect(comboManager.multiplier).toBe(1.5);
+      // accumulatedGrace = GRACE_PERIOD * 2 = 400
+
+      // Jump past timeout and register new kill
+      // Timeout = 1500 + 400 = 1900
+      vi.advanceTimersByTime(COMBO.TIMEOUT + COMBO.GRACE_PERIOD * 2 + 1);
+      comboManager.registerKill(Date.now());
+      expect(comboManager.multiplier).toBe(1.0);
+    });
+
+    it('should reset accumulatedGrace when combo expires', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      expect(comboManager.accumulatedGrace).toBe(COMBO.GRACE_PERIOD);
+
+      // Jump past timeout window (TIMEOUT + grace)
+      // Timeout = 1500 + 200 = 1700
+      vi.advanceTimersByTime(COMBO.TIMEOUT + COMBO.GRACE_PERIOD + 1);
+      comboManager.registerKill(Date.now());
+      expect(comboManager.accumulatedGrace).toBe(COMBO.GRACE_PERIOD);
+    });
+
+    it('should not reset if kill is within timeout window', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      const initialCount = comboManager.count;
+
+      // Kill within timeout but not immediately after
+      vi.advanceTimersByTime(COMBO.TIMEOUT - 50);
+      const result = comboManager.registerKill(Date.now());
+
+      expect(comboManager.count).toBe(initialCount + 1);
+      expect(result.isNewCombo).toBe(false);
+    });
+  });
+
+  describe('Multiplier scales correctly', () => {
+    it('should be 1.5 at 2x combo', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      expect(comboManager.multiplier).toBe(1.5);
+      expect(comboManager.getMultiplier()).toBe(1.5);
+    });
+
+    it('should be 2.0 at 3x combo', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      expect(comboManager.multiplier).toBe(2.0);
+    });
+
+    it('should be 2.5 at 4x combo', () => {
+      for (let i = 0; i < 4; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.multiplier).toBe(2.5);
+    });
+
+    it('should be 3.0 at 5x combo', () => {
+      for (let i = 0; i < 5; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.multiplier).toBe(3.0);
+    });
+
+    it('should stay at 3.0 for 5+ combos', () => {
+      for (let i = 0; i < 10; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.multiplier).toBe(3.0);
+    });
+
+    it('should be 1.0 for single kill', () => {
+      comboManager.registerKill(Date.now());
+      expect(comboManager.multiplier).toBe(1.0);
+    });
+  });
+
+  describe('Max combo is tracked correctly', () => {
+    it('should initialize maxCombo to 0', () => {
+      expect(comboManager.maxCombo).toBe(0);
+      expect(comboManager.getMaxCombo()).toBe(0);
+    });
+
+    it('should update maxCombo when combo exceeds previous max', () => {
+      for (let i = 0; i < 3; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.maxCombo).toBe(3);
+      expect(comboManager.getMaxCombo()).toBe(3);
+    });
+
+    it('should not decrease maxCombo when combo resets', () => {
+      for (let i = 0; i < 5; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.maxCombo).toBe(5);
+      // accumulatedGrace = GRACE_PERIOD * 5 = 1000
+
+      // Let combo timeout and start new one
+      // Timeout = 1500 + 1000 = 2500
+      vi.advanceTimersByTime(COMBO.TIMEOUT + COMBO.GRACE_PERIOD * 5 + 1);
+      comboManager.registerKill(Date.now());
+      expect(comboManager.count).toBe(1);
+      expect(comboManager.maxCombo).toBe(5); // Should not decrease
+    });
+
+    it('should track highest combo from multiple sessions', () => {
+      // First session: 3 kills
+      for (let i = 0; i < 3; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.maxCombo).toBe(3);
+      // accumulatedGrace = GRACE_PERIOD * 3 = 600
+
+      // Reset combo - timeout = 1500 + 600 = 2100
+      vi.advanceTimersByTime(COMBO.TIMEOUT + COMBO.GRACE_PERIOD * 3 + 1);
+      comboManager.registerKill(Date.now());
+
+      // Second session: 6 more kills (for total of 7, but first is already done)
+      for (let i = 1; i < 7; i++) {
+        vi.advanceTimersByTime(100);
+        comboManager.registerKill(Date.now());
+      }
+      expect(comboManager.maxCombo).toBe(7);
+    });
+  });
+
+  describe('Grace period extends timeout window', () => {
+    it('should extend timeout by GRACE_PERIOD per kill', () => {
+      // First kill at t=0
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+
+      // Second kill at t=100ms
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      comboManager.registerKill(killTime2);
+      // accumulatedGrace is now GRACE_PERIOD * 2 = 400
+
+      // Can still continue at just inside window from killTime2
+      // Timeout from killTime2 = 1500 + 400 = 1900
+      // Check at 1850ms after killTime2 (within window)
+      vi.advanceTimersByTime(COMBO.TIMEOUT + COMBO.GRACE_PERIOD - 50);
+      const result1 = comboManager.registerKill(Date.now());
+      expect(result1.isNewCombo).toBe(false);
+
+      // But after full timeout + grace, it should reset
+      vi.setSystemTime(0);
+      comboManager.reset();
+
+      const killTime3 = Date.now();
+      comboManager.registerKill(killTime3);
+      // accumulatedGrace = GRACE_PERIOD = 200
+      vi.advanceTimersByTime(100);
+      const killTime4 = Date.now();
+      comboManager.registerKill(killTime4);
+      // accumulatedGrace = GRACE_PERIOD * 2 = 400
+
+      // Now try at just past timeout without grace beyond second kill
+      // Timeout from killTime4 = 1500 + 400 = 1900
+      // Try at 1500.5 which is JUST past the base TIMEOUT from killTime4
+      vi.advanceTimersByTime(COMBO.TIMEOUT + 0.5); // Just past timeout
+      const result2 = comboManager.registerKill(Date.now());
+      // This should still be within the grace period window, so NOT a new combo
+      // So this test expectation needs to be adjusted
+      expect(result2.isNewCombo).toBe(false);
+    });
+
+    it('should allow combo to extend with accumulated grace periods', () => {
+      // Build up grace periods
+      for (let i = 0; i < 3; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      // accumulatedGrace should be 3 * GRACE_PERIOD
+
+      const totalTimeout = COMBO.TIMEOUT + 3 * COMBO.GRACE_PERIOD;
+
+      // Should still be able to continue at just before timeout + grace
+      vi.advanceTimersByTime(totalTimeout - 150);
+      const result = comboManager.registerKill(Date.now());
+      expect(result.isNewCombo).toBe(false);
+      expect(comboManager.count).toBe(4);
+    });
+  });
+
+  describe('isMilestone returns true for expected milestones', () => {
+    it('should return true for 2x combo', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      const result = comboManager.registerKill(Date.now());
+      expect(result.isMilestone).toBe(true);
+      expect(comboManager.isMilestoneCount(2)).toBe(true);
+    });
+
+    it('should return true for 3x combo', () => {
+      for (let i = 0; i < 3; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.isMilestoneCount(3)).toBe(true);
+    });
+
+    it('should return true for 5x combo', () => {
+      for (let i = 0; i < 5; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.isMilestoneCount(5)).toBe(true);
+    });
+
+    it('should return true for 10x combo', () => {
+      expect(comboManager.isMilestoneCount(10)).toBe(true);
+    });
+
+    it('should return true for 15x combo', () => {
+      expect(comboManager.isMilestoneCount(15)).toBe(true);
+    });
+
+    it('should return true for 20x combo', () => {
+      expect(comboManager.isMilestoneCount(20)).toBe(true);
+    });
+
+    it('should return true for all 5-count milestones (25, 30, 35...)', () => {
+      expect(comboManager.isMilestoneCount(25)).toBe(true);
+      expect(comboManager.isMilestoneCount(30)).toBe(true);
+      expect(comboManager.isMilestoneCount(35)).toBe(true);
+      expect(comboManager.isMilestoneCount(50)).toBe(true);
+    });
+  });
+
+  describe('isMilestone returns false for non-milestones', () => {
+    it('should return false for 1x combo', () => {
+      comboManager.registerKill(Date.now());
+      expect(comboManager.isMilestoneCount(1)).toBe(false);
+    });
+
+    it('should return false for 4x combo', () => {
+      expect(comboManager.isMilestoneCount(4)).toBe(false);
+    });
+
+    it('should return false for 6x combo', () => {
+      expect(comboManager.isMilestoneCount(6)).toBe(false);
+    });
+
+    it('should return false for 7x combo', () => {
+      expect(comboManager.isMilestoneCount(7)).toBe(false);
+    });
+
+    it('should return false for 8x combo', () => {
+      expect(comboManager.isMilestoneCount(8)).toBe(false);
+    });
+
+    it('should return false for 9x combo', () => {
+      expect(comboManager.isMilestoneCount(9)).toBe(false);
+    });
+
+    it('should return false for non-5-multiple combos above 5 (11, 12, 13, 14)', () => {
+      expect(comboManager.isMilestoneCount(11)).toBe(false);
+      expect(comboManager.isMilestoneCount(12)).toBe(false);
+      expect(comboManager.isMilestoneCount(13)).toBe(false);
+      expect(comboManager.isMilestoneCount(14)).toBe(false);
+    });
+  });
+
+  describe('isActive returns true when combo >= 2', () => {
+    it('should be false initially', () => {
+      expect(comboManager.isActive()).toBe(false);
+      expect(comboManager._isActive).toBe(false);
+    });
+
+    it('should be false after first kill', () => {
+      comboManager.registerKill(Date.now());
+      expect(comboManager.isActive()).toBe(false);
+    });
+
+    it('should be true after second kill', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      expect(comboManager.isActive()).toBe(true);
+    });
+
+    it('should remain true as combo increases', () => {
+      for (let i = 0; i < 5; i++) {
+        comboManager.registerKill(Date.now());
+        expect(comboManager.isActive()).toBe(comboManager.count >= 2);
+        vi.advanceTimersByTime(100);
+      }
+    });
+
+    it('should become false when combo resets', () => {
+      for (let i = 0; i < 3; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.isActive()).toBe(true);
+      // accumulatedGrace = GRACE_PERIOD * 3 = 600
+
+      // Let combo timeout via update()
+      // Timeout = 1500 + 600 = 2100
+      const lastKillTime = comboManager.lastKillTime;
+      comboManager.update(lastKillTime + 2101);
+      expect(comboManager.isActive()).toBe(false);
+    });
+  });
+
+  describe('update() correctly detects expired combos', () => {
+    it('should return comboBroken=false if combo is still active', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      comboManager.registerKill(killTime2);
+
+      // accumulatedGrace is now GRACE_PERIOD * 2 = 400
+      // timeout is COMBO.TIMEOUT + 400 = 1900
+      // Check at 500ms after killTime2 (well within timeout)
+      const result = comboManager.update(killTime2 + 500);
+      expect(result.comboBroken).toBe(false);
+      expect(result.previousCount).toBe(0);
+    });
+
+    it('should return comboBroken=true when combo expires', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      const result2 = comboManager.registerKill(killTime2);
+      expect(result2.comboCount).toBe(2);
+
+      // accumulatedGrace is GRACE_PERIOD * 2 = 400
+      // timeout is COMBO.TIMEOUT + 400 = 1900
+      // Check well after timeout expires
+      const updateResult = comboManager.update(killTime2 + 1901);
+      expect(updateResult.comboBroken).toBe(true);
+    });
+
+    it('should return previousCount when combo is broken', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      comboManager.registerKill(killTime2);
+      vi.advanceTimersByTime(100);
+      const killTime3 = Date.now();
+      comboManager.registerKill(killTime3);
+      expect(comboManager.count).toBe(3);
+
+      // accumulatedGrace is GRACE_PERIOD * 3 = 600
+      // timeout is COMBO.TIMEOUT + 600 = 2100
+      // Check well after timeout expires
+      const updateResult = comboManager.update(killTime3 + 2101);
+      expect(updateResult.previousCount).toBe(3);
+    });
+
+    it('should reset count to 0 when combo expires', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      comboManager.registerKill(killTime2);
+      expect(comboManager.count).toBe(2);
+
+      // accumulatedGrace is GRACE_PERIOD * 2 = 400
+      // timeout is COMBO.TIMEOUT + 400 = 1900
+      // Check well after timeout expires
+      comboManager.update(killTime2 + 1901);
+      expect(comboManager.count).toBe(0);
+    });
+
+    it('should reset multiplier to 1.0 when combo expires', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      comboManager.registerKill(killTime2);
+      expect(comboManager.multiplier).toBe(1.5);
+
+      // accumulatedGrace is GRACE_PERIOD * 2 = 400
+      // timeout is COMBO.TIMEOUT + 400 = 1900
+      // Check well after timeout expires
+      comboManager.update(killTime2 + 1901);
+      expect(comboManager.multiplier).toBe(1.0);
+    });
+
+    it('should set _isActive to false when combo expires', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      comboManager.registerKill(killTime2);
+      expect(comboManager._isActive).toBe(true);
+
+      // accumulatedGrace is GRACE_PERIOD * 2 = 400
+      // timeout is COMBO.TIMEOUT + 400 = 1900
+      // Check well after timeout expires
+      comboManager.update(killTime2 + 1901);
+      expect(comboManager._isActive).toBe(false);
+    });
+
+    it('should reset accumulatedGrace when combo expires', () => {
+      const killTime1 = Date.now();
+      comboManager.registerKill(killTime1);
+      vi.advanceTimersByTime(100);
+      const killTime2 = Date.now();
+      comboManager.registerKill(killTime2);
+      expect(comboManager.accumulatedGrace).toBe(COMBO.GRACE_PERIOD * 2);
+
+      // accumulatedGrace is GRACE_PERIOD * 2 = 400
+      // timeout is COMBO.TIMEOUT + 400 = 1900
+      // Check well after timeout expires
+      comboManager.update(killTime2 + 1901);
+      expect(comboManager.accumulatedGrace).toBe(0);
+    });
+
+    it('should not break combo when kill count is 0', () => {
+      const result = comboManager.update(Date.now() + 1000);
+      expect(result.comboBroken).toBe(false);
+      expect(result.previousCount).toBe(0);
+    });
+
+    it('should not break combo if lastKillTime is null', () => {
+      expect(comboManager.lastKillTime).toBeNull();
+      const result = comboManager.update(Date.now() + 1000);
+      expect(result.comboBroken).toBe(false);
+    });
+  });
+
+  describe('reset() clears all state', () => {
+    it('should reset count to 0', () => {
+      for (let i = 0; i < 5; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.count).toBe(5);
+
+      comboManager.reset();
+      expect(comboManager.count).toBe(0);
+    });
+
+    it('should reset multiplier to 1.0', () => {
+      for (let i = 0; i < 5; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.multiplier).toBe(3.0);
+
+      comboManager.reset();
+      expect(comboManager.multiplier).toBe(1.0);
+    });
+
+    it('should reset lastKillTime to null', () => {
+      comboManager.registerKill(Date.now());
+      expect(comboManager.lastKillTime).not.toBeNull();
+
+      comboManager.reset();
+      expect(comboManager.lastKillTime).toBeNull();
+    });
+
+    it('should reset maxCombo to 0 on reset', () => {
+      for (let i = 0; i < 7; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.maxCombo).toBe(7);
+
+      comboManager.reset();
+      expect(comboManager.maxCombo).toBe(0);
+    });
+
+    it('should reset _isActive to false', () => {
+      comboManager.registerKill(Date.now());
+      vi.advanceTimersByTime(100);
+      comboManager.registerKill(Date.now());
+      expect(comboManager._isActive).toBe(true);
+
+      comboManager.reset();
+      expect(comboManager._isActive).toBe(false);
+    });
+
+    it('should reset accumulatedGrace to 0', () => {
+      for (let i = 0; i < 3; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.accumulatedGrace).toBe(COMBO.GRACE_PERIOD * 3);
+
+      comboManager.reset();
+      expect(comboManager.accumulatedGrace).toBe(0);
+    });
+  });
+
+  describe('Getter methods work correctly', () => {
+    it('getCount() returns current count', () => {
+      for (let i = 0; i < 4; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.getCount()).toBe(4);
+    });
+
+    it('getMultiplier() returns current multiplier', () => {
+      for (let i = 0; i < 3; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.getMultiplier()).toBe(2.0);
+    });
+
+    it('getMaxCombo() returns max combo achieved', () => {
+      for (let i = 0; i < 6; i++) {
+        comboManager.registerKill(Date.now());
+        vi.advanceTimersByTime(100);
+      }
+      expect(comboManager.getMaxCombo()).toBe(6);
+    });
+  });
+});
+
+describe('PopupManager', () => {
+  let popupManager;
+
+  beforeEach(() => {
+    popupManager = new PopupManager();
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('Constructor initializes empty popups array', () => {
+    it('should initialize with empty popups array', () => {
+      expect(popupManager.popups).toEqual([]);
+      expect(Array.isArray(popupManager.popups)).toBe(true);
+    });
+
+    it('should have length 0', () => {
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should be able to push to popups array', () => {
+      popupManager.popups.push({ text: 'test' });
+      expect(popupManager.popups.length).toBe(1);
+    });
+  });
+
+  describe('add() creates popup with correct properties', () => {
+    it('should add popup with all provided parameters', () => {
+      popupManager.add('Test Text', 100, 200, '#FFFF00', 1000, 24);
+      expect(popupManager.popups.length).toBe(1);
+      const popup = popupManager.popups[0];
+      expect(popup.text).toBe('Test Text');
+      expect(popup.x).toBe(100);
+      expect(popup.y).toBe(200);
+      expect(popup.color).toBe('#FFFF00');
+      expect(popup.duration).toBe(1000);
+      expect(popup.fontSize).toBe(24);
+    });
+
+    it('should set createdAt to current Date.now()', () => {
+      popupManager.add('Test', 0, 0, '#FFF');
+      expect(popupManager.popups[0].createdAt).toBe(Date.now());
+    });
+
+    it('should initialize opacity to 1.0', () => {
+      popupManager.add('Test', 0, 0, '#FFF');
+      expect(popupManager.popups[0].opacity).toBe(1.0);
+    });
+
+    it('should initialize velocityY to negative RISE_SPEED', () => {
+      popupManager.add('Test', 0, 0, '#FFF');
+      expect(popupManager.popups[0].velocityY).toBe(-COMBO.POPUP.RISE_SPEED);
+    });
+
+    it('should use default duration from COMBO.POPUP.DURATION if not provided', () => {
+      popupManager.add('Test', 0, 0, '#FFF');
+      expect(popupManager.popups[0].duration).toBe(COMBO.POPUP.DURATION);
+    });
+
+    it('should use default fontSize from COMBO.POPUP.FONT_SIZE if not provided', () => {
+      popupManager.add('Test', 0, 0, '#FFF');
+      expect(popupManager.popups[0].fontSize).toBe(COMBO.POPUP.FONT_SIZE);
+    });
+
+    it('should add multiple popups', () => {
+      popupManager.add('First', 10, 20, '#FFF');
+      popupManager.add('Second', 30, 40, '#F00');
+      popupManager.add('Third', 50, 60, '#0F0');
+      expect(popupManager.popups.length).toBe(3);
+      expect(popupManager.popups[0].text).toBe('First');
+      expect(popupManager.popups[1].text).toBe('Second');
+      expect(popupManager.popups[2].text).toBe('Third');
+    });
+  });
+
+  describe('addComboPopup() formats text as "3x COMBO!"', () => {
+    it('should format combo popup with 1x', () => {
+      popupManager.addComboPopup(1, 100, 100);
+      const popup = popupManager.popups[0];
+      expect(popup.text).toBe('1x COMBO!');
+    });
+
+    it('should format combo popup with 3x', () => {
+      popupManager.addComboPopup(3, 100, 100);
+      const popup = popupManager.popups[0];
+      expect(popup.text).toBe('3x COMBO!');
+    });
+
+    it('should format combo popup with 10x', () => {
+      popupManager.addComboPopup(10, 100, 100);
+      const popup = popupManager.popups[0];
+      expect(popup.text).toBe('10x COMBO!');
+    });
+
+    it('should use COMBO.POPUP.COLOR', () => {
+      popupManager.addComboPopup(5, 100, 100);
+      expect(popupManager.popups[0].color).toBe(COMBO.POPUP.COLOR);
+    });
+
+    it('should use COMBO.POPUP.DURATION', () => {
+      popupManager.addComboPopup(5, 100, 100);
+      expect(popupManager.popups[0].duration).toBe(COMBO.POPUP.DURATION);
+    });
+
+    it('should use COMBO.POPUP.FONT_SIZE', () => {
+      popupManager.addComboPopup(5, 100, 100);
+      expect(popupManager.popups[0].fontSize).toBe(COMBO.POPUP.FONT_SIZE);
+    });
+
+    it('should set correct position', () => {
+      popupManager.addComboPopup(5, 250, 350);
+      const popup = popupManager.popups[0];
+      expect(popup.x).toBe(250);
+      expect(popup.y).toBe(350);
+    });
+  });
+
+  describe('addComboBrokenPopup() only adds popup if previousCount >= 2', () => {
+    it('should add popup when previousCount is 2', () => {
+      popupManager.addComboBrokenPopup(2, 100, 100);
+      expect(popupManager.popups.length).toBe(1);
+      expect(popupManager.popups[0].text).toBe('COMBO BROKEN');
+    });
+
+    it('should add popup when previousCount is 3', () => {
+      popupManager.addComboBrokenPopup(3, 100, 100);
+      expect(popupManager.popups.length).toBe(1);
+    });
+
+    it('should add popup when previousCount is 5', () => {
+      popupManager.addComboBrokenPopup(5, 100, 100);
+      expect(popupManager.popups.length).toBe(1);
+    });
+
+    it('should add popup when previousCount is 10', () => {
+      popupManager.addComboBrokenPopup(10, 100, 100);
+      expect(popupManager.popups.length).toBe(1);
+    });
+
+    it('should not add popup when previousCount is 0', () => {
+      popupManager.addComboBrokenPopup(0, 100, 100);
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should not add popup when previousCount is 1', () => {
+      popupManager.addComboBrokenPopup(1, 100, 100);
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should use COMBO.POPUP.BROKEN_COLOR', () => {
+      popupManager.addComboBrokenPopup(2, 100, 100);
+      expect(popupManager.popups[0].color).toBe(COMBO.POPUP.BROKEN_COLOR);
+    });
+
+    it('should use COMBO.POPUP.DURATION', () => {
+      popupManager.addComboBrokenPopup(2, 100, 100);
+      expect(popupManager.popups[0].duration).toBe(COMBO.POPUP.DURATION);
+    });
+
+    it('should use COMBO.POPUP.FONT_SIZE', () => {
+      popupManager.addComboBrokenPopup(2, 100, 100);
+      expect(popupManager.popups[0].fontSize).toBe(COMBO.POPUP.FONT_SIZE);
+    });
+
+    it('should set correct position', () => {
+      popupManager.addComboBrokenPopup(2, 200, 300);
+      const popup = popupManager.popups[0];
+      expect(popup.x).toBe(200);
+      expect(popup.y).toBe(300);
+    });
+  });
+
+  describe('update() moves popups upward', () => {
+    it('should decrease y position (move upward)', () => {
+      popupManager.add('Test', 100, 200, '#FFF');
+      const initialY = popupManager.popups[0].y;
+      popupManager.update(16); // ~1 frame at 60fps
+      const newY = popupManager.popups[0].y;
+      expect(newY).toBeLessThan(initialY);
+    });
+
+    it('should move by velocityY each frame', () => {
+      popupManager.add('Test', 100, 200, '#FFF');
+      const popup = popupManager.popups[0];
+      const initialY = popup.y;
+      const expectedVelocity = -COMBO.POPUP.RISE_SPEED;
+      popupManager.update(16);
+      expect(popup.y).toBe(initialY + expectedVelocity);
+    });
+
+    it('should continuously rise on multiple updates', () => {
+      popupManager.add('Test', 100, 200, '#FFF');
+      const popup = popupManager.popups[0];
+      const initialY = popup.y;
+      const expectedVelocity = -COMBO.POPUP.RISE_SPEED;
+
+      popupManager.update(16);
+      const afterFirstUpdate = popup.y;
+      expect(afterFirstUpdate).toBe(initialY + expectedVelocity);
+
+      popupManager.update(16);
+      const afterSecondUpdate = popup.y;
+      expect(afterSecondUpdate).toBe(afterFirstUpdate + expectedVelocity);
+    });
+
+    it('should update multiple popups independently', () => {
+      popupManager.add('First', 100, 200, '#FFF');
+      popupManager.add('Second', 100, 300, '#FFF');
+      popupManager.update(16);
+      const expectedVelocity = -COMBO.POPUP.RISE_SPEED;
+      expect(popupManager.popups[0].y).toBe(200 + expectedVelocity);
+      expect(popupManager.popups[1].y).toBe(300 + expectedVelocity);
+    });
+  });
+
+  describe('update() fades popups after FADE_START', () => {
+    it('should maintain opacity 1.0 before FADE_START', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 1000);
+      const popup = popupManager.popups[0];
+      expect(popup.opacity).toBe(1.0);
+
+      // Update at 50% duration (before FADE_START at 70%)
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION * 0.5);
+      popupManager.update(16);
+      expect(popup.opacity).toBe(1.0);
+    });
+
+    it('should start fading at FADE_START point', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 1000);
+      const popup = popupManager.popups[0];
+
+      // Update at FADE_START point
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION * COMBO.POPUP.FADE_START);
+      popupManager.update(16);
+      expect(popup.opacity).toBeLessThanOrEqual(1.0);
+    });
+
+    it('should fade from 1.0 to 0.0 during fade period', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 1000);
+      const popup = popupManager.popups[0];
+
+      // At 80% duration (20% through fade)
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION * 0.8);
+      popupManager.update(16);
+      const opacityAt80 = popup.opacity;
+      expect(opacityAt80).toBeGreaterThan(0);
+      expect(opacityAt80).toBeLessThan(1.0);
+
+      // At 95% duration (more faded)
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION * 0.15);
+      popupManager.update(16);
+      const opacityAt95 = popup.opacity;
+      expect(opacityAt95).toBeLessThan(opacityAt80);
+    });
+
+    it('should reach opacity close to 0 at end of duration', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 1000);
+      const popup = popupManager.popups[0];
+
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION - 1);
+      popupManager.update(16);
+      expect(popup.opacity).toBeLessThan(0.01);
+    });
+
+    it('should use correct fade calculation formula', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 1000);
+      const popup = popupManager.popups[0];
+      const createdAt = popup.createdAt;
+
+      // At 85% duration (15% through fade period which is 30%)
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION * 0.85);
+      popupManager.update(16);
+
+      const expectedProgress = 0.85;
+      const fadeProgress = (expectedProgress - COMBO.POPUP.FADE_START) / (1 - COMBO.POPUP.FADE_START);
+      const expectedOpacity = Math.max(0, 1.0 - fadeProgress);
+      expect(popup.opacity).toBeCloseTo(expectedOpacity, 1);
+    });
+  });
+
+  describe('update() removes expired popups', () => {
+    it('should remove popup when duration elapses', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 500);
+      expect(popupManager.popups.length).toBe(1);
+
+      vi.advanceTimersByTime(500);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should remove popup just after duration', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 500);
+      vi.advanceTimersByTime(501);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should not remove popup before duration', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 500);
+      vi.advanceTimersByTime(499);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(1);
+    });
+
+    it('should remove only expired popups, keep active ones', () => {
+      popupManager.add('First', 100, 100, '#FFF', 500);
+      const firstCreatedAt = popupManager.popups[0].createdAt;
+
+      vi.advanceTimersByTime(300);
+      popupManager.add('Second', 100, 100, '#FFF', 500);
+      expect(popupManager.popups.length).toBe(2);
+
+      // Advance to remove first but not second
+      vi.setSystemTime(firstCreatedAt + 501);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(1);
+      expect(popupManager.popups[0].text).toBe('Second');
+    });
+
+    it('should remove all expired popups when multiple expire', () => {
+      popupManager.add('First', 100, 100, '#FFF', 500);
+      popupManager.add('Second', 100, 100, '#FFF', 500);
+      popupManager.add('Third', 100, 100, '#FFF', 500);
+      expect(popupManager.popups.length).toBe(3);
+
+      vi.advanceTimersByTime(501);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(0);
+    });
+  });
+
+  describe('getPopups() returns popups array', () => {
+    it('should return empty array initially', () => {
+      const popups = popupManager.getPopups();
+      expect(popups).toEqual([]);
+      expect(Array.isArray(popups)).toBe(true);
+    });
+
+    it('should return array with added popups', () => {
+      popupManager.add('Test1', 100, 100, '#FFF');
+      popupManager.add('Test2', 200, 200, '#FFF');
+      const popups = popupManager.getPopups();
+      expect(popups.length).toBe(2);
+      expect(popups[0].text).toBe('Test1');
+      expect(popups[1].text).toBe('Test2');
+    });
+
+    it('should return reference to internal popups array', () => {
+      popupManager.add('Test', 100, 100, '#FFF');
+      const popups = popupManager.getPopups();
+      expect(popups).toBe(popupManager.popups);
+    });
+
+    it('should reflect changes after update()', () => {
+      popupManager.add('Test', 100, 100, '#FFF', 100);
+      vi.advanceTimersByTime(101);
+      popupManager.update(16);
+      const popups = popupManager.getPopups();
+      expect(popups.length).toBe(0);
+    });
+  });
+
+  describe('clear() removes all popups', () => {
+    it('should empty popups array', () => {
+      popupManager.add('Test1', 100, 100, '#FFF');
+      popupManager.add('Test2', 100, 100, '#FFF');
+      expect(popupManager.popups.length).toBe(2);
+
+      popupManager.clear();
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should create new empty array', () => {
+      popupManager.add('Test', 100, 100, '#FFF');
+      const oldArray = popupManager.popups;
+      popupManager.clear();
+      expect(popupManager.popups).not.toBe(oldArray);
+      expect(popupManager.popups).toEqual([]);
+    });
+
+    it('should work when already empty', () => {
+      expect(popupManager.popups.length).toBe(0);
+      popupManager.clear();
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should allow adding popups after clear', () => {
+      popupManager.add('Test1', 100, 100, '#FFF');
+      popupManager.clear();
+      popupManager.add('Test2', 200, 200, '#FFF');
+      expect(popupManager.popups.length).toBe(1);
+      expect(popupManager.popups[0].text).toBe('Test2');
+    });
+  });
+
+  describe('reset() is alias for clear()', () => {
+    it('should remove all popups', () => {
+      popupManager.add('Test1', 100, 100, '#FFF');
+      popupManager.add('Test2', 100, 100, '#FFF');
+      popupManager.reset();
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should work the same as clear()', () => {
+      popupManager.add('Test1', 100, 100, '#FFF');
+      popupManager.add('Test2', 100, 100, '#FFF');
+      const lenBeforeClear = popupManager.popups.length;
+
+      popupManager.clear();
+      const lenAfterClear = popupManager.popups.length;
+
+      popupManager.add('Test3', 100, 100, '#FFF');
+      popupManager.add('Test4', 100, 100, '#FFF');
+      popupManager.reset();
+      const lenAfterReset = popupManager.popups.length;
+
+      expect(lenAfterClear).toBe(lenAfterReset);
+    });
+
+    it('should create new array like clear()', () => {
+      popupManager.add('Test', 100, 100, '#FFF');
+      const oldArray = popupManager.popups;
+      popupManager.reset();
+      expect(popupManager.popups).not.toBe(oldArray);
+    });
+  });
+
+  describe('Integration tests', () => {
+    it('should handle combo popup lifecycle', () => {
+      popupManager.addComboPopup(5, 100, 200);
+      expect(popupManager.popups.length).toBe(1);
+      expect(popupManager.popups[0].text).toBe('5x COMBO!');
+
+      // Update mid-duration
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION * 0.5);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(1);
+      expect(popupManager.popups[0].opacity).toBe(1.0);
+
+      // Update past FADE_START
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION * 0.3);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(1);
+      expect(popupManager.popups[0].opacity).toBeLessThan(1.0);
+
+      // Update past duration
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION * 0.2);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should handle combo broken popup lifecycle', () => {
+      popupManager.addComboBrokenPopup(3, 150, 250);
+      expect(popupManager.popups.length).toBe(1);
+      expect(popupManager.popups[0].text).toBe('COMBO BROKEN');
+      expect(popupManager.popups[0].color).toBe(COMBO.POPUP.BROKEN_COLOR);
+
+      vi.advanceTimersByTime(COMBO.POPUP.DURATION + 1);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(0);
+    });
+
+    it('should handle multiple popups with different lifespans', () => {
+      popupManager.add('First', 100, 100, '#FFF', 500);
+      const firstCreatedAt = Date.now();
+
+      vi.advanceTimersByTime(100);
+      popupManager.add('Second', 100, 100, '#FFF', 800);
+      const secondCreatedAt = Date.now();
+
+      // First expires
+      vi.setSystemTime(firstCreatedAt + 501);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(1);
+      expect(popupManager.popups[0].text).toBe('Second');
+
+      // Second expires
+      vi.setSystemTime(secondCreatedAt + 801);
+      popupManager.update(16);
+      expect(popupManager.popups.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements Issue #10: Combo System

- 🔥 Chain kills within 1.5s to build combos
- 💰 Score multipliers: 2x=×1.5, 3x=×2.0, 4x=×2.5, 5+=×3.0
- 💬 Yellow floating popups show combo count at kill location
- 🔴 Red "COMBO BROKEN" popup when combo expires
- 🔊 Rising arpeggio sound at milestones, descending on break
- 📊 Combo HUD displays current combo and multiplier
- 🏆 Max combo tracked in high score entries

## Changes

### New Files
| File | Lines | Description |
|------|-------|-------------|
| `src/managers/combo-manager.js` | 205 | ComboManager class |
| `src/managers/popup-manager.js` | 141 | PopupManager for floating text |
| `tests/combo-system.test.js` | 1,161 | 124 unit tests |

### Modified Files
- `src/constants.js` - Added `COMBO` configuration
- `src/game.js` - Integrated combo tracking
- `src/audio/sound-manager.js` - Combo sound effects
- `src/renderer/canvas-renderer.js` - Combo HUD and popups
- `src/managers/score-manager.js` - Max combo tracking
- `README.md` - Documentation for combo system

## Multiplier Table

| Combo | Multiplier |
|-------|------------|
| 2x | ×1.5 |
| 3x | ×2.0 |
| 4x | ×2.5 |
| 5x+ | ×3.0 |

## Test Plan
- [x] 634 tests passing (124 new combo tests)
- [x] Build successful
- [ ] Manual test: Kill 2 enemies within 1.5s → shows "2x COMBO!"
- [ ] Manual test: Kill 5+ enemies → shows maximum ×3.0 multiplier
- [ ] Manual test: Wait >1.5s → shows "COMBO BROKEN" popup
- [ ] Manual test: Check high score shows max combo

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)